### PR TITLE
Packing to center

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Places each given node. It is assumed that the remaining nodes in the graph alre
 
 ```instance.packComponents(components)```
 
-Packs components of a disconnected graph.
+Packs components of a disconnected graph. Layout is done in a way that it preserves the center of the  [bounding rectangle](occupiedRectangleReal) of components. 
 The function parameter has two arrays, namely nodes and edges. Each node has properties (x, y), top left corner coordinate of the node, width and height. Each edge has the properties (startX, startY), (endX, endY) representing the starting and ending points of the edge, respectively.
 
 The function returns an object which has the following properties:

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Places each given node. It is assumed that the remaining nodes in the graph alre
 
 ```instance.packComponents(components)```
 
-Packs components of a disconnected graph. Layout is done in a way that it preserves the center of the  [bounding rectangle](occupiedRectangleReal) of components. 
+Packs components of a disconnected graph. Layout is done in a way that it preserves the center of the  [bounding rectangle](https://en.wikipedia.org/wiki/Minimum_bounding_rectangle) of components. 
 The function parameter has two arrays, namely nodes and edges. Each node has properties (x, y), top left corner coordinate of the node, width and height. Each edge has the properties (startX, startY), (endX, endY) representing the starting and ending points of the edge, respectively.
 
 The function returns an object which has the following properties:

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Places each given node. It is assumed that the remaining nodes in the graph alre
 
 ```instance.packComponents(components)```
 
-Packs components of a disconnected graph. Layout is done in a way that it preserves the center of the  [bounding rectangle](https://en.wikipedia.org/wiki/Minimum_bounding_rectangle) of components. 
+Packs components of a disconnected graph. Packing is done in a way that it preserves the center of the  [bounding rectangle](https://en.wikipedia.org/wiki/Minimum_bounding_rectangle) of components. 
 The function parameter has two arrays, namely nodes and edges. Each node has properties (x, y), top left corner coordinate of the node, width and height. Each edge has the properties (startX, startY), (endX, endY) representing the starting and ending points of the edge, respectively.
 
 The function returns an object which has the following properties:

--- a/cytoscape-layout-utilities.js
+++ b/cytoscape-layout-utilities.js
@@ -87,8 +87,6 @@ var _createClass = function () { function defineProperties(target, props) { for 
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-var generalUtils = __webpack_require__(1);
-
 var Polyomino = function () {
     function Polyomino(width, height, index, leftMostCoord, topMostCoord) {
         _classCallCheck(this, Polyomino);
@@ -111,7 +109,7 @@ var Polyomino = function () {
     }
 
     _createClass(Polyomino, [{
-        key: 'getBoundingRectangle',
+        key: "getBoundingRectangle",
         value: function getBoundingRectangle() {
             var polyx1 = this.location.x - this.center.x;
             var polyy1 = this.location.y - this.center.y;
@@ -138,7 +136,7 @@ var Point = function () {
 
 
     _createClass(Point, [{
-        key: 'diff',
+        key: "diff",
         value: function diff(other) {
             return new Point(other.x - this.x, other.y - this.y);
         }
@@ -158,7 +156,7 @@ var BoundingRectangle = function () {
     }
 
     _createClass(BoundingRectangle, [{
-        key: 'center',
+        key: "center",
         value: function center() {
             return new Point((this.x2 - this.x1) / 2, (this.y2 - this.y1) / 2);
         }
@@ -197,7 +195,7 @@ var Grid = function () {
 
 
     _createClass(Grid, [{
-        key: 'getDirectNeighbors',
+        key: "getDirectNeighbors",
         value: function getDirectNeighbors(cells, level) {
             var resultPoints = [];
             if (cells.length == 0) {
@@ -231,7 +229,7 @@ var Grid = function () {
         //given a cell at locatoin i,j get the unvistied unoccupied neighboring cell
 
     }, {
-        key: 'getCellNeighbors',
+        key: "getCellNeighbors",
         value: function getCellNeighbors(i, j) {
             var resultPoints = [];
             //check all the 8 surrounding cells 
@@ -298,7 +296,7 @@ var Grid = function () {
         // a function to place a given polyomino in the cell i j on the grid
 
     }, {
-        key: 'placePolyomino',
+        key: "placePolyomino",
         value: function placePolyomino(polyomino, i, j) {
             polyomino.location.x = i;
             polyomino.location.y = j;
@@ -340,7 +338,7 @@ var Grid = function () {
         // a function to determine if a polyomino can be placed on the given cell i,j
 
     }, {
-        key: 'tryPlacingPolyomino',
+        key: "tryPlacingPolyomino",
         value: function tryPlacingPolyomino(polyomino, i, j) {
             for (var k = 0; k < polyomino.width; k++) {
                 for (var l = 0; l < polyomino.height; l++) {
@@ -360,7 +358,7 @@ var Grid = function () {
         //calculates the value of the utility (aspect ratio) of placing a polyomino on cell i,j
 
     }, {
-        key: 'calculateUtilityOfPlacing',
+        key: "calculateUtilityOfPlacing",
         value: function calculateUtilityOfPlacing(polyomino, i, j, desiredAspectRatio) {
             var result = {};
             var actualAspectRatio = 1;
@@ -413,114 +411,7 @@ module.exports = {
 "use strict";
 
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
-var generalUtils = {};
-var polyominoPacking = __webpack_require__(0);
-
-var _require = __webpack_require__(0),
-    Point = _require.Point;
-
-//a function to remove duplicate object in array
-
-
-generalUtils.uniqueArray = function (ar) {
-  var j = {};
-  ar.forEach(function (v) {
-    j[v + '::' + (typeof v === 'undefined' ? 'undefined' : _typeof(v))] = v;
-  });
-  return Object.keys(j).map(function (v) {
-    return j[v];
-  });
-};
-
-//a function to determine the grid cells where a line between point p0 and p1 pass through
-generalUtils.LineSuperCover = function (p0, p1) {
-  var dx = p1.x - p0.x,
-      dy = p1.y - p0.y;
-  var nx = Math.floor(Math.abs(dx)),
-      ny = Math.floor(Math.abs(dy));
-  var sign_x = dx > 0 ? 1 : -1,
-      sign_y = dy > 0 ? 1 : -1;
-
-  var p = new polyominoPacking.Point(p0.x, p0.y);
-  var points = [new polyominoPacking.Point(p.x, p.y)];
-  for (var ix = 0, iy = 0; ix < nx || iy < ny;) {
-    if ((0.5 + ix) / nx == (0.5 + iy) / ny) {
-      // next step is diagonal
-      p.x += sign_x;
-      p.y += sign_y;
-      ix++;
-      iy++;
-    } else if ((0.5 + ix) / nx < (0.5 + iy) / ny) {
-      // next step is horizontal
-      p.x += sign_x;
-      ix++;
-    } else {
-      // next step is vertical
-      p.y += sign_y;
-      iy++;
-    }
-    points.push(new polyominoPacking.Point(p.x, p.y));
-  }
-  return points;
-};
-
-/**
- * finds the current center of components
- * @param { Array } components 
- */
-generalUtils.getCenter = function (components) {
-  // In case the platform doesn't have flatMap function
-  if (typeof Array.prototype['flatMap'] === 'undefined') {
-    Array.prototype['flatMap'] = function (f) {
-      var concat = function concat(x, y) {
-        return x.concat(y);
-      };
-      var flatMap = function flatMap(f, xs) {
-        return xs.map(f).reduce(concat, []);
-      };
-
-      return flatMap(f, this);
-    };
-  }
-
-  var bounds = components.flatMap(function (component) {
-    return component.nodes;
-  }).map(function (node) {
-    return {
-      left: node.x,
-      top: node.y,
-      right: node.x + node.width,
-      bottom: node.y + node.height
-    };
-  }).reduce(function (bounds, currNode) {
-    return {
-      left: currNode.left < bounds.left ? currNode.left : bounds.left,
-      right: currNode.right > bounds.right ? currNode.right : bounds.right,
-      top: currNode.top < bounds.top ? currNode.top : bounds.top,
-      bottom: currNode.bottom > bounds.bottom ? currNode.bottom : bounds.bottom
-    };
-  }, {
-    left: Number.MAX_VALUE,
-    right: Number.MIN_VALUE,
-    top: Number.MAX_VALUE,
-    bottom: Number.MIN_VALUE
-  });
-
-  return new Point((bounds.left + bounds.right) / 2, (bounds.top + bounds.bottom) / 2);
-};
-
-module.exports = generalUtils;
-
-/***/ }),
-/* 2 */
-/***/ (function(module, exports, __webpack_require__) {
-
-"use strict";
-
-
-var generalUtils = __webpack_require__(1);
+var generalUtils = __webpack_require__(2);
 var polyominoPacking = __webpack_require__(0);
 
 var _require = __webpack_require__(0),
@@ -667,8 +558,6 @@ var layoutUtilities = function layoutUtilities(cy, options) {
         component[0].position("x", x);
         component[0].position("y", y);
       } else {
-        var max = 0;
-        var index = 0;
         var positioned = [];
         for (var i = 0; i < component.length; i++) {
           positioned.push(false);
@@ -952,9 +841,6 @@ var layoutUtilities = function layoutUtilities(cy, options) {
       polyominos.push(componentPolyomino);
     });
 
-    // These variables are not used anywhere. Should be safe to remove
-    var componentsCenter = new polyominoPacking.Point((globalX1 + globalX2) / 2, (globalY1 + globalY2) / 2);
-    var componentsCenteronGrid = new polyominoPacking.Point(Math.floor(componentsCenter.x / gridStep), Math.floor(componentsCenter.y / gridStep));
     //order plyominos non-increasing order
     polyominos.sort(function (a, b) {
       var aSize = a.width * a.height;
@@ -1050,7 +936,7 @@ var layoutUtilities = function layoutUtilities(cy, options) {
     /*  var shiftX = componentsCenter.x - ((mainGrid.center.x - mainGrid.occupiedRectangle.x1)*gridStep); 
      var shiftY = componentsCenter.y - ((mainGrid.center.y - mainGrid.occupiedRectangle.y1)*gridStep); 
      var occupiedCenterX = Math.floor((mainGrid.occupiedRectangle.x1 + mainGrid.occupiedRectangle.x2)/2);
-     var occupiedCenterY = Math.floor((mainGrid.occupiedRectangle.y1 + mainGrid.occupiedRectangle.y2)/2); */7;
+     var occupiedCenterY = Math.floor((mainGrid.occupiedRectangle.y1 + mainGrid.occupiedRectangle.y2)/2); */
     // Calculate the difference between old center and new center
     var rectCenter = mainGrid.occupiedRectangle.center();
     var renderedCenter = new Point(rectCenter.x * gridStep, rectCenter.y * gridStep);
@@ -1086,6 +972,113 @@ var layoutUtilities = function layoutUtilities(cy, options) {
 module.exports = layoutUtilities;
 
 /***/ }),
+/* 2 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+var generalUtils = {};
+var polyominoPacking = __webpack_require__(0);
+
+var _require = __webpack_require__(0),
+    Point = _require.Point;
+
+//a function to remove duplicate object in array
+
+
+generalUtils.uniqueArray = function (ar) {
+  var j = {};
+  ar.forEach(function (v) {
+    j[v + '::' + (typeof v === 'undefined' ? 'undefined' : _typeof(v))] = v;
+  });
+  return Object.keys(j).map(function (v) {
+    return j[v];
+  });
+};
+
+//a function to determine the grid cells where a line between point p0 and p1 pass through
+generalUtils.LineSuperCover = function (p0, p1) {
+  var dx = p1.x - p0.x,
+      dy = p1.y - p0.y;
+  var nx = Math.floor(Math.abs(dx)),
+      ny = Math.floor(Math.abs(dy));
+  var sign_x = dx > 0 ? 1 : -1,
+      sign_y = dy > 0 ? 1 : -1;
+
+  var p = new polyominoPacking.Point(p0.x, p0.y);
+  var points = [new polyominoPacking.Point(p.x, p.y)];
+  for (var ix = 0, iy = 0; ix < nx || iy < ny;) {
+    if ((0.5 + ix) / nx == (0.5 + iy) / ny) {
+      // next step is diagonal
+      p.x += sign_x;
+      p.y += sign_y;
+      ix++;
+      iy++;
+    } else if ((0.5 + ix) / nx < (0.5 + iy) / ny) {
+      // next step is horizontal
+      p.x += sign_x;
+      ix++;
+    } else {
+      // next step is vertical
+      p.y += sign_y;
+      iy++;
+    }
+    points.push(new polyominoPacking.Point(p.x, p.y));
+  }
+  return points;
+};
+
+/**
+ * finds the current center of components
+ * @param { Array } components 
+ */
+generalUtils.getCenter = function (components) {
+  // In case the platform doesn't have flatMap function
+  if (typeof Array.prototype['flatMap'] === 'undefined') {
+    Array.prototype['flatMap'] = function (f) {
+      var concat = function concat(x, y) {
+        return x.concat(y);
+      };
+      var flatMap = function flatMap(f, xs) {
+        return xs.map(f).reduce(concat, []);
+      };
+
+      return flatMap(f, this);
+    };
+  }
+
+  var bounds = components.flatMap(function (component) {
+    return component.nodes;
+  }).map(function (node) {
+    return {
+      left: node.x,
+      top: node.y,
+      right: node.x + node.width,
+      bottom: node.y + node.height
+    };
+  }).reduce(function (bounds, currNode) {
+    return {
+      left: currNode.left < bounds.left ? currNode.left : bounds.left,
+      right: currNode.right > bounds.right ? currNode.right : bounds.right,
+      top: currNode.top < bounds.top ? currNode.top : bounds.top,
+      bottom: currNode.bottom > bounds.bottom ? currNode.bottom : bounds.bottom
+    };
+  }, {
+    left: Number.MAX_VALUE,
+    right: Number.MIN_VALUE,
+    top: Number.MAX_VALUE,
+    bottom: Number.MIN_VALUE
+  });
+
+  return new Point((bounds.left + bounds.right) / 2, (bounds.top + bounds.bottom) / 2);
+};
+
+module.exports = generalUtils;
+
+/***/ }),
 /* 3 */
 /***/ (function(module, exports, __webpack_require__) {
 
@@ -1094,7 +1087,6 @@ var __WEBPACK_AMD_DEFINE_RESULT__;
 
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
-;
 (function () {
   'use strict';
 
@@ -1139,7 +1131,7 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
          }
          return obj;
       }; */
-    var layoutUtilities = __webpack_require__(2);
+    var layoutUtilities = __webpack_require__(1);
 
     cytoscape('core', 'layoutUtilities', function (opts) {
       var cy = this;
@@ -1177,7 +1169,7 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
         }
 
         return out;
-      };
+      }
 
       options = extendOptions({}, options, opts);
 

--- a/cytoscape-layout-utilities.js
+++ b/cytoscape-layout-utilities.js
@@ -1,1 +1,1272 @@
-!function(e,t){"object"==typeof exports&&"object"==typeof module?module.exports=t():"function"==typeof define&&define.amd?define([],t):"object"==typeof exports?exports.cytoscapeLayoutUtilities=t():e.cytoscapeLayoutUtilities=t()}(this,function(){return function(e){function t(o){if(i[o])return i[o].exports;var n=i[o]={i:o,l:!1,exports:{}};return e[o].call(n.exports,n,n.exports,t),n.l=!0,n.exports}var i={};return t.m=e,t.c=i,t.i=function(e){return e},t.d=function(e,i,o){t.o(e,i)||Object.defineProperty(e,i,{configurable:!1,enumerable:!0,get:o})},t.n=function(e){var i=e&&e.__esModule?function(){return e.default}:function(){return e};return t.d(i,"a",i),i},t.o=function(e,t){return Object.prototype.hasOwnProperty.call(e,t)},t.p="",t(t.s=3)}([function(e,t,i){"use strict";var o="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e},n={},r=i(1);n.uniqueArray=function(e){var t={};return e.forEach(function(e){t[e+"::"+(void 0===e?"undefined":o(e))]=e}),Object.keys(t).map(function(e){return t[e]})},n.LineSuperCover=function(e,t){for(var i=t.x-e.x,o=t.y-e.y,n=Math.floor(Math.abs(i)),s=Math.floor(Math.abs(o)),c=i>0?1:-1,h=o>0?1:-1,a=new r.Point(e.x,e.y),d=[new r.Point(a.x,a.y)],u=0,f=0;u<n||f<s;)(.5+u)/n==(.5+f)/s?(a.x+=c,a.y+=h,u++,f++):(.5+u)/n<(.5+f)/s?(a.x+=c,u++):(a.y+=h,f++),d.push(new r.Point(a.x,a.y));return d},e.exports=n},function(e,t,i){"use strict";function o(e,t){if(!(e instanceof t))throw new TypeError("Cannot call a class as a function")}var n=function(){function e(e,t){for(var i=0;i<t.length;i++){var o=t[i];o.enumerable=o.enumerable||!1,o.configurable=!0,"value"in o&&(o.writable=!0),Object.defineProperty(e,o.key,o)}}return function(t,i,o){return i&&e(t.prototype,i),o&&e(t,o),t}}(),r=(i(0),function e(t,i,n,r,c){o(this,e),this.grid=new Array(t);for(var h=0;h<t;h++){this.grid[h]=new Array(i);for(var a=0;a<i;a++)this.grid[h][a]=!1}this.index=n,this.leftMostCoord=r,this.topMostCoord=c,this.width=t,this.height=i,this.location=new s(-1,-1),this.center=new s(Math.floor(t/2),Math.floor(i/2)),this.numberOfOccupiredCells=0}),s=function e(t,i){o(this,e),this.x=t,this.y=i},c=function e(t,i,n,r){o(this,e),this.x1=t,this.x2=n,this.y1=i,this.y2=r},h=function e(t,i){o(this,e),this.occupied=t,this.visited=i},a=function(){function e(t,i){o(this,e),this.width=t,this.height=i,this.grid=new Array(t);for(var n=0;n<t;n++){this.grid[n]=new Array(i);for(var r=0;r<i;r++)this.grid[n][r]=new h(!1,!1)}this.center=new s(Math.floor(t/2),Math.floor(i/2)),this.occupiedRectangle=new c(0,0,0,0),this.numberOfOccupiredCells=0}return n(e,[{key:"getDirectNeighbors",value:function(e,t){var i=[];if(0==e.length){for(var o=0;o<this.width;o++)for(var n=0;n<this.height;n++)this.grid[o][n].occupied&&(i=i.concat(this.getCellNeighbors(o,n)));for(var r=0,s=i.length-1,o=2;o<=t;o++){if(s>=r)for(var n=r;n<=s;n++)i=i.concat(this.getCellNeighbors(i[n].x,i[n].y));r=s+1,s=i.length-1}}else e.forEach(function(e){i=i.concat(this.getCellNeighbors(e.x,e.y))}.bind(this));return i}},{key:"getCellNeighbors",value:function(e,t){var i=[];return e-1>=0&&(this.grid[e-1][t].occupied||this.grid[e-1][t].visited||(i.push({x:e-1,y:t}),this.grid[e-1][t].visited=!0)),e+1<this.width&&(this.grid[e+1][t].occupied||this.grid[e+1][t].visited||(i.push({x:e+1,y:t}),this.grid[e+1][t].visited=!0)),t-1>=0&&(this.grid[e][t-1].occupied||this.grid[e][t-1].visited||(i.push({x:e,y:t-1}),this.grid[e][t-1].visited=!0)),t+1<this.height&&(this.grid[e][t+1].occupied||this.grid[e][t+1].visited||(i.push({x:e,y:t+1}),this.grid[e][t+1].visited=!0)),e-1>=0&&(this.grid[e-1][t].occupied||this.grid[e-1][t].visited||(i.push({x:e-1,y:t}),this.grid[e-1][t].visited=!0)),e-1>=0&&t-1>=0&&(this.grid[e-1][t-1].occupied||this.grid[e-1][t-1].visited||(i.push({x:e-1,y:t-1}),this.grid[e-1][t-1].visited=!0)),e+1<this.width&&t-1>=0&&(this.grid[e+1][t-1].occupied||this.grid[e+1][t-1].visited||(i.push({x:e+1,y:t-1}),this.grid[e+1][t-1].visited=!0)),e-1>=0&&t+1<this.height&&(this.grid[e-1][t+1].occupied||this.grid[e-1][t+1].visited||(i.push({x:e-1,y:t+1}),this.grid[e-1][t+1].visited=!0)),e+1<this.width&&t+1<this.height&&(this.grid[e+1][t+1].occupied||this.grid[e+1][t+1].visited||(i.push({x:e+1,y:t+1}),this.grid[e+1][t+1].visited=!0)),i}},{key:"placePolyomino",value:function(e,t,i){e.location.x=t,e.location.y=i;for(var o=0;o<e.width;o++)for(var n=0;n<e.height;n++)e.grid[o][n]&&(this.grid[o-e.center.x+t][n-e.center.y+i].occupied=!0);this.numberOfOccupiredCells+=e.numberOfOccupiredCells;for(var r=1e4,s=0,c=1e4,h=0,a=0;a<this.width;a++)for(var d=0;d<this.height;d++)this.grid[a][d].visited=!1,this.grid[a][d].occupied&&(a<=r&&(r=a),d<=c&&(c=d),a>=s&&(s=a),d>=h&&(h=d));this.occupiedRectangle.x1=r,this.occupiedRectangle.y1=c,this.occupiedRectangle.x2=s,this.occupiedRectangle.y2=h}},{key:"tryPlacingPolyomino",value:function(e,t,i){for(var o=0;o<e.width;o++)for(var n=0;n<e.height;n++){if(o-e.center.x+t>=this.width||o-e.center.x+t<0||n-e.center.y+i>=this.height||n-e.center.y+i<0)return!1;if(e.grid[o][n]&&this.grid[o-e.center.x+t][n-e.center.y+i].occupied)return!1}return!0}},{key:"calculateUtilityOfPlacing",value:function(e,t,i,o){var n={},r=1,s=1,c=1,h=this.occupiedRectangle.x1,a=this.occupiedRectangle.x2,d=this.occupiedRectangle.y1,u=this.occupiedRectangle.y2;t-e.center.x<h&&(h=t-e.center.x),i-e.center.y<d&&(d=i-e.center.y),e.width-1-e.center.x+t>a&&(a=e.width-1-e.center.x+t),e.height-1-e.center.y+i>u&&(u=e.height-1-e.center.y+i);var f=a-h+1,l=u-d+1;return r=f/l,s=(this.numberOfOccupiredCells+e.numberOfOccupiredCells)/(f*l),c=r>o?(this.numberOfOccupiredCells+e.numberOfOccupiredCells)/(f*(f/o)):(this.numberOfOccupiredCells+e.numberOfOccupiredCells)/(l*o*l),n.actualAspectRatio=r,n.fullness=s,n.adjustedFullness=c,n}}]),e}();e.exports={Grid:a,Polyomino:r,BoundingRectangle:c,Point:s}},function(e,t,i){"use strict";var o=i(0),n=i(1),r=function(e,t){var i={};return i.placeHiddenNodes=function(e){e.forEach(function(e){e.neighborhood().nodes(":hidden").forEach(function(t){t.neighborhood().nodes(":visible").length>1?i.nodeWithMultipleNeighbors(t):i.nodeWithOneNeighbor(e,t)})})},i.placeNewNodes=function(e){for(var o=this.findComponents(e),n=[],r=0;r<o.length;r++){for(var s,c=!1,h=!1,a=[],d=[],u=0,f=0,l=!1,p=0;p<o[r].length;p++){var g=o[r][p].neighborhood().nodes().difference(e);d.push(!1),g.length>1&&!l?(h=!0,d[p]=!0,a=g,i.nodeWithMultipleNeighbors(o[r][p],a),u=o[r][p].position("x"),f=o[r][p].position("y"),l=!0):1!=g.length||l||(c=!0,s=g[0],d[p]=!0,i.nodeWithOneNeighbor(s,o[r][p]),u=o[r][p].position("x"),f=o[r][p].position("y"),l=!0)}if(c||h){for(var p=0;p<o[r].length;p++)if(0==d[p]){var g=o[r][p].neighborhood().nodes(),y=[],v=o[r][p].neighborhood().nodes().difference(e);v.forEach(function(e){y.push(e)});for(var x=0;x<g.length;x++)d[o[r].indexOf(g[x])]&&y.push(g[x]);if(y.length>1)i.nodeWithMultipleNeighbors(o[r][p],y);else if(1==y.length)i.nodeWithOneNeighbor(y[0],o[r][p]);else{var b=i.generateRandom(t.offset,2*t.offset,0),m=i.generateRandom(t.offset,2*t.offset,0);o[r][p].position("x",u+b),o[r][p].position("y",f+m)}d[p]=!0}}else n.push(o[r])}n.length>=1&&i.disconnectedNodes(n)},i.disconnectedNodes=function(o){var n=Number.MAX_VALUE,r=Number.MIN_VALUE,s=Number.MAX_VALUE,c=Number.MIN_VALUE;e.nodes(":visible").forEach(function(e){var t=e.outerWidth()/2,i=e.outerHeight()/2;e.position("x")-t<n&&(n=e.position("x")-t),e.position("x")+t>r&&(r=e.position("x")+t),e.position("y")-i<s&&(s=e.position("y")-i),e.position("y")+i>c&&(c=e.position("y")+i)});var h=s-c,a=r-n,d=Math.sqrt(a*a+h*h)/2,u=(n+r)/2,f=(s+c)/2,l=o.length,p=360/l,g=1;o.forEach(function(e){var o=i.generateRandom(d+6*t.offset,d+8*t.offset,1),n=p*g,r=n*Math.PI/180,s=u+o*Math.cos(r),c=f+o*Math.sin(r);if(1==e.length)e[0].position("x",s),e[0].position("y",c);else{for(var h=[],a=0;a<e.length;a++)h.push(!1);h[0]=!0,e[0].position("x",s),e[0].position("y",c);for(var a=1;a<e.length;a++){for(var l=e[a].neighborhood().nodes(),y=[],v=0;v<l.length;v++)h[e.indexOf(l[v])]&&y.push(l[v]);if(y.length>1)i.nodeWithMultipleNeighbors(e[a],y);else if(1==y.length)i.nodeWithOneNeighbor(y[0],e[a]);else{var x=i.generateRandom(t.offset,2*t.offset,0),b=i.generateRandom(t.offset,2*t.offset,0);e[a].position("x",s+x),e[a].position("y",c+b)}h[a]=!0}}g++})},i.findComponents=function(t){var i=[],o=e.nodes().difference(t);t.forEach(function(e){var n=e.neighborhood().nodes().difference(o),r=[];n.forEach(function(e){var i=t.indexOf(e);r.push(i)}),i.push(r)});for(var n=[],r=0;r<t.length;r++)n.push(!1);for(var s=[],r=0;r<t.length;r++){var c=[];0==n[r]&&(this.DFSUtil(r,n,i,t,c),s.push(c))}return s},i.DFSUtil=function(e,t,i,o,n){t[e]=!0,n.push(o[e]);for(var r=0;r<i[e].length;r++)t[i[e][r]]||this.DFSUtil(i[e][r],t,i,o,n)},i.nodeWithOneNeighbor=function(e,o){var n=i.checkOccupiedQuadrants(e,o),r=[];for(var s in n)"free"===n[s]&&r.push(s);var c,h;if(r.length>0)if(3===r.length)r.includes("first")&&r.includes("second")&&r.includes("third")?(c=-1,h=-1):r.includes("first")&&r.includes("second")&&r.includes("fourth")?(c=1,h=-1):r.includes("first")&&r.includes("third")&&r.includes("fourth")?(c=1,h=1):r.includes("second")&&r.includes("third")&&r.includes("fourth")&&(c=-1,h=1);else{var a=r[Math.floor(Math.random()*r.length)];"first"===a?(c=1,h=-1):"second"===a?(c=-1,h=-1):"third"===a?(c=-1,h=1):"fourth"===a&&(c=1,h=1)}else c=0,h=0;var d=i.generateRandom(t.idealEdgeLength-t.offset,t.idealEdgeLength+t.offset,c),u=i.generateRandom(t.idealEdgeLength-t.offset,t.idealEdgeLength+t.offset,h),f=e.position("x")+d,l=e.position("y")+u;o.position("x",f),o.position("y",l)},i.nodeWithMultipleNeighbors=function(e,o){if(null==o)var o=e.neighborhood().nodes(":visible");var n=0,r=0,s=0;o.forEach(function(e){n+=e.position("x"),r+=e.position("y"),s++}),n/=s,r/=s;var c=i.generateRandom(0,t.offset/2,0),h=i.generateRandom(0,t.offset/2,0);e.position("x",n+c),e.position("y",r+h)},i.generateRandom=function(e,t,i){var o=[-1,1];return 0===i&&(i=o[Math.floor(Math.random()*o.length)]),(Math.floor(Math.random()*(t-e+1))+e)*i},i.checkOccupiedQuadrants=function(e,t){var i=e.neighborhood().difference(t).nodes(),o={first:"free",second:"free",third:"free",fourth:"free"};return i.forEach(function(t){"compartment"!=t.data("class")&&"complex"!=t.data("class")&&(t.position("x")<e.position("x")&&t.position("y")<e.position("y")?o.second="occupied":t.position("x")>e.position("x")&&t.position("y")<e.position("y")?o.first="occupied":t.position("x")<e.position("x")&&t.position("y")>e.position("y")?o.third="occupied":t.position("x")>e.position("x")&&t.position("y")>e.position("y")&&(o.fourth="occupied"))}),o},i.packComponents=function(e){var i=0,r=0;if(e.forEach(function(e){r+=e.nodes.length,e.nodes.forEach(function(e){i+=e.width+e.height})}),i/=2*r,i=Math.floor(i*t.polyominoGridSizeFactor),t.componentSpacing>0){var s=t.componentSpacing;e.forEach(function(e){e.nodes.forEach(function(e){e.x=e.x-s,e.y=e.y-s,e.width=e.width+2*s,e.height=e.height+2*s})})}var c=0,h=0,a=[],d=1e4,u=0,f=1e4,l=0;e.forEach(function(e,t){var r=1e4,s=0,p=1e4,g=0;e.nodes.forEach(function(e){e.x<=r&&(r=e.x),e.y<=p&&(p=e.y),e.x+e.width>=s&&(s=e.x+e.width),e.y+e.height>=g&&(g=e.y+e.height)}),e.edges.forEach(function(e){e.startX<=r&&(r=e.startX),e.startY<=p&&(p=e.startY),e.endX>=s&&(s=e.endX),e.endY>=g&&(g=e.endY)}),r<d&&(d=r),s>u&&(u=s),p<f&&(f=p),g>l&&(l=g),c+=s-r,h+=g-p;var y=Math.floor((s-r)/i)+1,v=Math.floor((g-p)/i)+1,x=new n.Polyomino(y,v,t,r,p);e.nodes.forEach(function(e){for(var t=Math.floor((e.x-r)/i),o=Math.floor((e.y-p)/i),n=Math.floor((e.x+e.width-r)/i),s=Math.floor((e.y+e.height-p)/i),c=t;c<=n;c++)for(var h=o;h<=s;h++)x.grid[c][h]=!0}),e.edges.forEach(function(e){var t={},n={};t.x=(e.startX-r)/i,t.y=(e.startY-p)/i,n.x=(e.endX-r)/i,n.y=(e.endY-p)/i,o.LineSuperCover(t,n).forEach(function(e){var t=Math.floor(e.x),i=Math.floor(e.y);t>=0&&t<x.width&&i>=0&&i<x.height&&(x.grid[Math.floor(e.x)][Math.floor(e.y)]=!0)})});for(var b=0;b<x.width;b++)for(var m=0;m<x.height;m++)x.grid[b][m]&&x.numberOfOccupiredCells++;a.push(x)});var p=new n.Point((d+u)/2,(f+l)/2);new n.Point(Math.floor(p.x/i),Math.floor(p.y/i));a.sort(function(e,t){var i=e.width*e.height,o=t.width*t.height;return i>o?-1:i<o?1:0}),c=Math.ceil(2*c/i),h=Math.ceil(2*h/i);var g=new n.Grid(c+1,h+1);g.placePolyomino(a[0],g.center.x,g.center.y);for(var y=1;y<a.length;y++){for(var v=0,x=0,b=0,m=1e6,M=!1,R=[],w={};!M;)R=g.getDirectNeighbors(R,Math.ceil(Math.max(a[y].width,a[y].height)/2)),R.forEach(function(e){if(g.tryPlacingPolyomino(a[y],e.x,e.y)){M=!0;var i=g.calculateUtilityOfPlacing(a[y],e.x,e.y,t.desiredAspectRatio),o=!1;if(1==t.utilityFunction)i.adjustedFullness>x?o=!0:i.adjustedFullness==x&&(i.fullness>v?o=!0:i.fullness==v&&Math.abs(i.actualAspectRatio-t.desiredAspectRatio)<=m&&(o=!0)),o&&(x=i.adjustedFullness,m=Math.abs(i.actualAspectRatio-t.desiredAspectRatio),v=i.fullness,w.x=e.x,w.y=e.y);else if(2==t.utilityFunction){var n=Math.abs(i.actualAspectRatio-t.desiredAspectRatio),r=.5*i.fullness+(1-n/Math.max(i.actualAspectRatio,t.desiredAspectRatio)*.5);r>b&&(b=r,w.x=e.x,w.y=e.y)}}});g.placePolyomino(a[y],w.x,w.y)}a.sort(function(e,t){return e.index<t.index?-1:e.index>t.index?1:0});var O={};if(O.shifts=[],a.forEach(function(e){var t=(e.location.x-e.center.x-g.occupiedRectangle.x1)*i-e.leftMostCoord,o=(e.location.y-e.center.y-g.occupiedRectangle.y1)*i-e.topMostCoord;O.shifts.push({dx:t,dy:o})}),O.aspectRatio=Math.round((g.occupiedRectangle.x2-g.occupiedRectangle.x1+1)/(g.occupiedRectangle.y2-g.occupiedRectangle.y1+1)*100)/100,O.fullness=Math.round(g.numberOfOccupiredCells/((g.occupiedRectangle.x2-g.occupiedRectangle.x1+1)*(g.occupiedRectangle.y2-g.occupiedRectangle.y1+1))*100*100)/100,O.aspectRatio>t.desiredAspectRatio){var E=g.occupiedRectangle.x2-g.occupiedRectangle.x1+1;O.adjustedFullness=Math.round(g.numberOfOccupiredCells/(E*(E/t.desiredAspectRatio))*100*100)/100}else{var C=g.occupiedRectangle.y2-g.occupiedRectangle.y1+1;O.adjustedFullness=Math.round(g.numberOfOccupiredCells/(C*t.desiredAspectRatio*C)*100*100)/100}return O},i};e.exports=r},function(e,t,i){"use strict";var o,n="function"==typeof Symbol&&"symbol"==typeof Symbol.iterator?function(e){return typeof e}:function(e){return e&&"function"==typeof Symbol&&e.constructor===Symbol&&e!==Symbol.prototype?"symbol":typeof e};!function(){var r=function(e){if(e){var t={idealEdgeLength:50,offset:20,desiredAspectRatio:1,polyominoGridSizeFactor:1,utilityFunction:1,componentSpacing:30},o=i(2);e("core","layoutUtilities",function(e){function i(e){e=e||{};for(var t=1;t<arguments.length;t++){var o=arguments[t];if(o)for(var r in o)o.hasOwnProperty(r)&&(Array.isArray(o[r])?e[r]=o[r].slice():"object"===n(o[r])?e[r]=i(e[r],o[r]):e[r]=o[r])}return e}function r(e){return e.scratch("_layoutUtilities")||e.scratch("_layoutUtilities",{}),e.scratch("_layoutUtilities")}var s=this;if("get"===e)return r(s).instance;t=i({},t,e);var c=o(s,t);if(r(s).instance=c,!r(s).initialized){r(s).initialized=!0;var h=!1;document.addEventListener("keydown",function(e){"Shift"==e.key&&(h=!0)}),document.addEventListener("keyup",function(e){"Shift"==e.key&&(h=!1)})}return r(s).instance})}};void 0!==e&&e.exports&&(e.exports=r),void 0!==(o=function(){return r}.call(t,i,t,e))&&(e.exports=o),"undefined"!=typeof cytoscape&&r(cytoscape)}()}])});
+(function webpackUniversalModuleDefinition(root, factory) {
+	if(typeof exports === 'object' && typeof module === 'object')
+		module.exports = factory();
+	else if(typeof define === 'function' && define.amd)
+		define([], factory);
+	else if(typeof exports === 'object')
+		exports["cytoscapeLayoutUtilities"] = factory();
+	else
+		root["cytoscapeLayoutUtilities"] = factory();
+})(this, function() {
+return /******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// identity function for calling harmony imports with the correct context
+/******/ 	__webpack_require__.i = function(value) { return value; };
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, {
+/******/ 				configurable: false,
+/******/ 				enumerable: true,
+/******/ 				get: getter
+/******/ 			});
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "";
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 3);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var generalUtils = __webpack_require__(1);
+
+var Polyomino = function Polyomino(width, height, index, leftMostCoord, topMostCoord) {
+    _classCallCheck(this, Polyomino);
+
+    this.grid = new Array(width);
+    for (var i = 0; i < width; i++) {
+        this.grid[i] = new Array(height);
+        for (var j = 0; j < height; j++) {
+            this.grid[i][j] = false;
+        }
+    }
+    this.index = index; //index of polyomino in the input of the packing function
+    this.leftMostCoord = leftMostCoord; //kept to determine the amount of shift in the output
+    this.topMostCoord = topMostCoord; //kept to determine the amount of shift in the output
+    this.width = width;
+    this.height = height;
+    this.location = new Point(-1, -1); //the grid cell coordinates where the polyomino was placed
+    this.center = new Point(Math.floor(width / 2), Math.floor(height / 2)); // center of polyomino
+    this.numberOfOccupiredCells = 0;
+};
+
+var Point = function () {
+    function Point(x, y) {
+        _classCallCheck(this, Point);
+
+        this.x = x;
+        this.y = y;
+    }
+
+    /**
+     * Returns other - this for x and y
+     * @param { Point } other
+     */
+
+
+    _createClass(Point, [{
+        key: 'diff',
+        value: function diff(other) {
+            return new Point(other.x - this.x, other.y - this.y);
+        }
+    }]);
+
+    return Point;
+}();
+
+var BoundingRectangle = function () {
+    function BoundingRectangle(x1, y1, x2, y2) {
+        _classCallCheck(this, BoundingRectangle);
+
+        this.x1 = x1;
+        this.x2 = x2;
+        this.y1 = y1;
+        this.y2 = y2;
+    }
+
+    _createClass(BoundingRectangle, [{
+        key: 'center',
+        value: function center() {
+            return new Point((this.x2 - this.x1) / 2, (this.y2 - this.y1) / 2);
+        }
+    }]);
+
+    return BoundingRectangle;
+}();
+
+var Cell = function Cell(occupied, visited) {
+    _classCallCheck(this, Cell);
+
+    this.occupied = occupied; //boolean to determine if the cell is occupied
+    this.visited = visited; //boolean to determine if the cell was visited before while traversing the cells
+};
+
+var Grid = function () {
+    function Grid(width, height) {
+        _classCallCheck(this, Grid);
+
+        this.width = width;
+        this.height = height;
+        //create and intialize the grid
+        this.grid = new Array(width);
+        for (var i = 0; i < width; i++) {
+            this.grid[i] = new Array(height);
+            for (var j = 0; j < height; j++) {
+                this.grid[i][j] = new Cell(false, false);
+            }
+        }
+        this.center = new Point(Math.floor(width / 2), Math.floor(height / 2));
+        this.occupiedRectangle = new BoundingRectangle(Number.MAX_VALUE, Number.MAX_VALUE, Number.MIN_VALUE, Number.MIN_VALUE); // the bounding rectanble of the occupied cells in the grid
+        this.numberOfOccupiredCells = 0;
+    }
+
+    //function given a list of cells it returns the direct unvisited unoccupied neighboring cells 
+
+
+    _createClass(Grid, [{
+        key: 'getDirectNeighbors',
+        value: function getDirectNeighbors(cells, level) {
+            var resultPoints = [];
+            if (cells.length == 0) {
+                for (var i = 0; i < this.width; i++) {
+                    for (var j = 0; j < this.height; j++) {
+                        if (this.grid[i][j].occupied) {
+                            resultPoints = resultPoints.concat(this.getCellNeighbors(i, j));
+                        }
+                    }
+                }
+                var startIndex = 0;
+                var endIndex = resultPoints.length - 1;
+
+                for (var i = 2; i <= level; i++) {
+
+                    if (endIndex >= startIndex) {
+                        for (var j = startIndex; j <= endIndex; j++) {
+                            resultPoints = resultPoints.concat(this.getCellNeighbors(resultPoints[j].x, resultPoints[j].y));
+                        }
+                    }
+
+                    startIndex = endIndex + 1;
+                    endIndex = resultPoints.length - 1;
+                }
+            } else {
+                cells.forEach(function (cell) {
+                    resultPoints = resultPoints.concat(this.getCellNeighbors(cell.x, cell.y));
+                }.bind(this));
+            }
+            return resultPoints;
+        }
+
+        //given a cell at locatoin i,j get the unvistied unoccupied neighboring cell
+
+    }, {
+        key: 'getCellNeighbors',
+        value: function getCellNeighbors(i, j) {
+            var resultPoints = [];
+            //check all the 8 surrounding cells 
+            if (i - 1 >= 0) {
+                if (!this.grid[i - 1][j].occupied && !this.grid[i - 1][j].visited) {
+                    resultPoints.push({ x: i - 1, y: j });
+                    this.grid[i - 1][j].visited = true;
+                }
+            }
+            if (i + 1 < this.width) {
+                if (!this.grid[i + 1][j].occupied && !this.grid[i + 1][j].visited) {
+                    resultPoints.push({ x: i + 1, y: j });
+                    this.grid[i + 1][j].visited = true;
+                }
+            }
+            if (j - 1 >= 0) {
+                if (!this.grid[i][j - 1].occupied && !this.grid[i][j - 1].visited) {
+                    resultPoints.push({ x: i, y: j - 1 });
+                    this.grid[i][j - 1].visited = true;
+                }
+            }
+            if (j + 1 < this.height) {
+                if (!this.grid[i][j + 1].occupied && !this.grid[i][j + 1].visited) {
+                    resultPoints.push({ x: i, y: j + 1 });
+                    this.grid[i][j + 1].visited = true;
+                }
+            }
+            if (i - 1 >= 0) {
+                if (!this.grid[i - 1][j].occupied && !this.grid[i - 1][j].visited) {
+                    resultPoints.push({ x: i - 1, y: j });
+                    this.grid[i - 1][j].visited = true;
+                }
+            }
+            if (i - 1 >= 0 && j - 1 >= 0) {
+                if (!this.grid[i - 1][j - 1].occupied && !this.grid[i - 1][j - 1].visited) {
+                    resultPoints.push({ x: i - 1, y: j - 1 });
+                    this.grid[i - 1][j - 1].visited = true;
+                }
+            }
+
+            if (i + 1 < this.width && j - 1 >= 0) {
+                if (!this.grid[i + 1][j - 1].occupied && !this.grid[i + 1][j - 1].visited) {
+                    resultPoints.push({ x: i + 1, y: j - 1 });
+                    this.grid[i + 1][j - 1].visited = true;
+                }
+            }
+
+            if (i - 1 >= 0 && j + 1 < this.height) {
+                if (!this.grid[i - 1][j + 1].occupied && !this.grid[i - 1][j + 1].visited) {
+                    resultPoints.push({ x: i - 1, y: j + 1 });
+                    this.grid[i - 1][j + 1].visited = true;
+                }
+            }
+            if (i + 1 < this.width && j + 1 < this.height) {
+                if (!this.grid[i + 1][j + 1].occupied && !this.grid[i + 1][j + 1].visited) {
+                    resultPoints.push({ x: i + 1, y: j + 1 });
+                    this.grid[i + 1][j + 1].visited = true;
+                }
+            }
+
+            return resultPoints;
+        }
+
+        // a function to place a given polyomino in the cell i j on the grid
+
+    }, {
+        key: 'placePolyomino',
+        value: function placePolyomino(polyomino, i, j) {
+            polyomino.location.x = i;
+            polyomino.location.y = j;
+            for (var k = 0; k < polyomino.width; k++) {
+                for (var l = 0; l < polyomino.height; l++) {
+                    if (polyomino.grid[k][l]) {
+                        //if [k] [l] cell is occupied in polyomino
+                        this.grid[k - polyomino.center.x + i][l - polyomino.center.y + j].occupied = true;
+                    }
+                }
+            }
+
+            //update number of occupired cells
+            this.numberOfOccupiredCells += polyomino.numberOfOccupiredCells;
+
+            //update bounding rectangle and reset visited cells to none
+            var x1 = 10000,
+                x2 = 0,
+                y1 = 10000,
+                y2 = 0;
+            for (var x = 0; x < this.width; x++) {
+                for (var y = 0; y < this.height; y++) {
+                    this.grid[x][y].visited = false;
+                    if (this.grid[x][y].occupied) {
+                        if (x <= x1) x1 = x;
+                        if (y <= y1) y1 = y;
+                        if (x >= x2) x2 = x;
+                        if (y >= y2) y2 = y;
+                    }
+                }
+            }
+            this.occupiedRectangle.x1 = x1, this.occupiedRectangle.y1 = y1;
+            this.occupiedRectangle.x2 = x2;
+            this.occupiedRectangle.y2 = y2;
+        }
+
+        // a function to determine if a polyomino can be placed on the given cell i,j
+
+    }, {
+        key: 'tryPlacingPolyomino',
+        value: function tryPlacingPolyomino(polyomino, i, j) {
+            for (var k = 0; k < polyomino.width; k++) {
+                for (var l = 0; l < polyomino.height; l++) {
+                    //return false if polyomino goes outside the grid when placed on i,j
+                    if (k - polyomino.center.x + i >= this.width || k - polyomino.center.x + i < 0 || l - polyomino.center.y + j >= this.height || l - polyomino.center.y + j < 0) {
+                        return false;
+                    }
+                    //return false if the  polymino cell and the corrosponding main grid cell are both occupied
+                    if (polyomino.grid[k][l] && this.grid[k - polyomino.center.x + i][l - polyomino.center.y + j].occupied) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        //calculates the value of the utility (aspect ratio) of placing a polyomino on cell i,j
+
+    }, {
+        key: 'calculateUtilityOfPlacing',
+        value: function calculateUtilityOfPlacing(polyomino, i, j, desiredAspectRatio) {
+            var result = {};
+            var actualAspectRatio = 1;
+            var fullness = 1;
+            var adjustedFullness = 1;
+            var x1 = this.occupiedRectangle.x1;
+            var x2 = this.occupiedRectangle.x2;
+            var y1 = this.occupiedRectangle.y1;
+            var y2 = this.occupiedRectangle.y2;
+            if (i - polyomino.center.x < x1) x1 = i - polyomino.center.x;
+            if (j - polyomino.center.y < y1) y1 = j - polyomino.center.y;
+            if (polyomino.width - 1 - polyomino.center.x + i > x2) x2 = polyomino.width - 1 - polyomino.center.x + i;
+            if (polyomino.height - 1 - polyomino.center.y + j > y2) y2 = polyomino.height - 1 - polyomino.center.y + j;
+            var width = x2 - x1 + 1;
+            var height = y2 - y1 + 1;
+            actualAspectRatio = width / height;
+            fullness = (this.numberOfOccupiredCells + polyomino.numberOfOccupiredCells) / (width * height);
+
+            if (actualAspectRatio > desiredAspectRatio) {
+                adjustedFullness = (this.numberOfOccupiredCells + polyomino.numberOfOccupiredCells) / (width * (width / desiredAspectRatio));
+                // height = width / desiredAspectRatio;
+            } else {
+
+                adjustedFullness = (this.numberOfOccupiredCells + polyomino.numberOfOccupiredCells) / (height * desiredAspectRatio * height);
+
+                // width = height * desiredAspectRatio;
+            }
+
+            result.actualAspectRatio = actualAspectRatio;
+            result.fullness = fullness;
+            result.adjustedFullness = adjustedFullness;
+
+            return result;
+        }
+    }]);
+
+    return Grid;
+}();
+
+module.exports = {
+    Grid: Grid,
+    Polyomino: Polyomino,
+    BoundingRectangle: BoundingRectangle,
+    Point: Point
+
+};
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+var generalUtils = {};
+var polyominoPacking = __webpack_require__(0);
+
+var _require = __webpack_require__(0),
+    Point = _require.Point;
+
+//a function to remove duplicate object in array
+
+
+generalUtils.uniqueArray = function (ar) {
+  var j = {};
+  ar.forEach(function (v) {
+    j[v + '::' + (typeof v === 'undefined' ? 'undefined' : _typeof(v))] = v;
+  });
+  return Object.keys(j).map(function (v) {
+    return j[v];
+  });
+};
+
+//a function to determine the grid cells where a line between point p0 and p1 pass through
+generalUtils.LineSuperCover = function (p0, p1) {
+  var dx = p1.x - p0.x,
+      dy = p1.y - p0.y;
+  var nx = Math.floor(Math.abs(dx)),
+      ny = Math.floor(Math.abs(dy));
+  var sign_x = dx > 0 ? 1 : -1,
+      sign_y = dy > 0 ? 1 : -1;
+
+  var p = new polyominoPacking.Point(p0.x, p0.y);
+  var points = [new polyominoPacking.Point(p.x, p.y)];
+  for (var ix = 0, iy = 0; ix < nx || iy < ny;) {
+    if ((0.5 + ix) / nx == (0.5 + iy) / ny) {
+      // next step is diagonal
+      p.x += sign_x;
+      p.y += sign_y;
+      ix++;
+      iy++;
+    } else if ((0.5 + ix) / nx < (0.5 + iy) / ny) {
+      // next step is horizontal
+      p.x += sign_x;
+      ix++;
+    } else {
+      // next step is vertical
+      p.y += sign_y;
+      iy++;
+    }
+    points.push(new polyominoPacking.Point(p.x, p.y));
+  }
+  return points;
+};
+
+/**
+ * finds the current center of components
+ * @param { Array } components 
+ */
+generalUtils.getCenter = function (components) {
+  // In case the platform doesn't have flatMap function
+  if (typeof Array.prototype['flatMap'] === 'undefined') {
+    Array.prototype['flatMap'] = function (f) {
+      var concat = function concat(x, y) {
+        return x.concat(y);
+      };
+      var flatMap = function flatMap(f, xs) {
+        return xs.map(f).reduce(concat, []);
+      };
+
+      return flatMap(f, this);
+    };
+  }
+
+  var bounds = components.flatMap(function (component) {
+    return component.nodes;
+  }).map(function (node) {
+    return {
+      left: node.x,
+      top: node.y,
+      right: node.x + node.width,
+      bottom: node.y + node.height
+    };
+  }).reduce(function (bounds, currNode) {
+    if (currNode.left < bounds.left) {
+      bounds.left = currNode.left;
+    }
+    if (currNode.right > bounds.right) {
+      bounds.right = currNode.right;
+    }
+    if (currNode.top < bounds.top) {
+      bounds.top = currNode.top;
+    }
+    if (currNode.bottom > bounds.bottom) {
+      bounds.bottom = currNode.bottom;
+    }
+
+    return bounds;
+  }, {
+    left: Number.MAX_VALUE,
+    right: Number.MIN_VALUE,
+    top: Number.MAX_VALUE,
+    bottom: Number.MIN_VALUE
+  });
+
+  return new Point((bounds.left + bounds.right) / 2, (bounds.top + bounds.bottom) / 2);
+};
+
+module.exports = generalUtils;
+
+/***/ }),
+/* 2 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var generalUtils = __webpack_require__(1);
+var polyominoPacking = __webpack_require__(0);
+
+var _require = __webpack_require__(0),
+    Point = _require.Point;
+
+var layoutUtilities = function layoutUtilities(cy, options) {
+
+  /*  var defaults = {
+     idealEdgeLength : 50,
+     offset : 20,
+     desiredAspectRatio : 1,
+     polyominoGridSizeFactor : 1,
+     utilityFunction : 1
+   };
+    function extend(defaults, options) {
+     var obj = {};
+      for (var i in defaults) {
+       obj[i] = defaults[i];
+     }
+      for (var i in options) {      
+       obj[i] = options[i];
+     }
+      return obj;
+   };
+    options = extend(defaults, options); */
+  var instance = {};
+
+  instance.placeHiddenNodes = function (mainEles) {
+    mainEles.forEach(function (mainEle) {
+      var hiddenEles = mainEle.neighborhood().nodes(":hidden");
+      hiddenEles.forEach(function (hiddenEle) {
+        var neighbors = hiddenEle.neighborhood().nodes(":visible");
+        if (neighbors.length > 1) {
+          instance.nodeWithMultipleNeighbors(hiddenEle);
+        } else instance.nodeWithOneNeighbor(mainEle, hiddenEle);
+      });
+    });
+  };
+
+  instance.placeNewNodes = function (eles) {
+    var components = this.findComponents(eles);
+    var disconnectedComp = [];
+    for (var i = 0; i < components.length; i++) {
+      var oneNeig = false;
+      var multNeig = false;
+      var mainEle;
+      var multneighbors = [];
+      var positioned = [];
+      var x = 0;
+      var y = 0;
+      var isPositioned = false;
+      for (var j = 0; j < components[i].length; j++) {
+        var neighbors = components[i][j].neighborhood().nodes().difference(eles);
+        positioned.push(false);
+        if (neighbors.length > 1 && !isPositioned) {
+          multNeig = true;
+          positioned[j] = true;
+          multneighbors = neighbors;
+          instance.nodeWithMultipleNeighbors(components[i][j], multneighbors);
+          x = components[i][j].position("x");
+          y = components[i][j].position("y");
+          isPositioned = true;
+        } else if (neighbors.length == 1 && !isPositioned) {
+          oneNeig = true;
+          mainEle = neighbors[0];
+          positioned[j] = true;
+          instance.nodeWithOneNeighbor(mainEle, components[i][j]);
+          x = components[i][j].position("x");
+          y = components[i][j].position("y");
+          isPositioned = true;
+        }
+      }
+
+      if (oneNeig || multNeig) {
+        for (var j = 0; j < components[i].length; j++) {
+          if (positioned[j] == false) {
+            var neighbors = components[i][j].neighborhood().nodes();
+            var positionedNeigbors = [];
+            var curr = components[i][j].neighborhood().nodes().difference(eles);
+            curr.forEach(function (ele) {
+              positionedNeigbors.push(ele);
+            });
+
+            for (var k = 0; k < neighbors.length; k++) {
+              if (positioned[components[i].indexOf(neighbors[k])]) {
+                positionedNeigbors.push(neighbors[k]);
+              }
+            }
+            if (positionedNeigbors.length > 1) {
+              instance.nodeWithMultipleNeighbors(components[i][j], positionedNeigbors);
+            } else if (positionedNeigbors.length == 1) instance.nodeWithOneNeighbor(positionedNeigbors[0], components[i][j]);else {
+              var horizontalP = instance.generateRandom(options.offset, options.offset * 2, 0);
+              var verticalP = instance.generateRandom(options.offset, options.offset * 2, 0);
+              components[i][j].position("x", x + horizontalP);
+              components[i][j].position("y", y + verticalP);
+            }
+            positioned[j] = true;
+          }
+        }
+      } else {
+        disconnectedComp.push(components[i]);
+      }
+    }
+
+    if (disconnectedComp.length >= 1) {
+      instance.disconnectedNodes(disconnectedComp);
+    }
+  };
+
+  instance.disconnectedNodes = function (components) {
+    var leftX = Number.MAX_VALUE;
+    var rightX = Number.MIN_VALUE;
+    var topY = Number.MAX_VALUE;
+    var bottomY = Number.MIN_VALUE;
+    // Check the x and y limits of all hidden elements and store them in the variables above
+    cy.nodes(':visible').forEach(function (node) {
+      var halfWidth = node.outerWidth() / 2;
+      var halfHeight = node.outerHeight() / 2;
+      if (node.position("x") - halfWidth < leftX) leftX = node.position("x") - halfWidth;
+      if (node.position("x") + halfWidth > rightX) rightX = node.position("x") + halfWidth;
+      if (node.position("y") - halfHeight < topY) topY = node.position("y") - halfHeight;
+      if (node.position("y") + halfHeight > bottomY) bottomY = node.position("y") + halfHeight;
+    });
+
+    var radiusy = topY - bottomY;
+    var radiusx = rightX - leftX;
+    var innerRadius = Math.sqrt(radiusx * radiusx + radiusy * radiusy) / 2;
+    var centerX = (leftX + rightX) / 2;
+    var centerY = (topY + bottomY) / 2;
+    //var components = this.findComponents(newEles);
+    var numOfComponents = components.length;
+    var angle = 360 / numOfComponents;
+    var count = 1;
+
+    components.forEach(function (component) {
+
+      var distFromCenter = instance.generateRandom(innerRadius + options.offset * 6, innerRadius + options.offset * 8, 1);
+      var curAngle = angle * count;
+      var angleInRadians = curAngle * Math.PI / 180;
+      var x = centerX + distFromCenter * Math.cos(angleInRadians);
+      var y = centerY + distFromCenter * Math.sin(angleInRadians);
+
+      if (component.length == 1) {
+        component[0].position("x", x);
+        component[0].position("y", y);
+      } else {
+        var max = 0;
+        var index = 0;
+        var positioned = [];
+        for (var i = 0; i < component.length; i++) {
+          positioned.push(false);
+        }
+
+        positioned[0] = true;
+        component[0].position("x", x);
+        component[0].position("y", y);
+
+        for (var i = 1; i < component.length; i++) {
+          var neighbors = component[i].neighborhood().nodes();
+          var positionedNeigbors = [];
+          for (var j = 0; j < neighbors.length; j++) {
+            if (positioned[component.indexOf(neighbors[j])]) {
+              positionedNeigbors.push(neighbors[j]);
+            }
+          }
+          if (positionedNeigbors.length > 1) {
+            instance.nodeWithMultipleNeighbors(component[i], positionedNeigbors);
+          } else if (positionedNeigbors.length == 1) instance.nodeWithOneNeighbor(positionedNeigbors[0], component[i]);else {
+            var horizontalP = instance.generateRandom(options.offset, options.offset * 2, 0);
+            var verticalP = instance.generateRandom(options.offset, options.offset * 2, 0);
+            component[i].position("x", x + horizontalP);
+            component[i].position("y", y + verticalP);
+          }
+          positioned[i] = true;
+        }
+      }
+      count++;
+    });
+  };
+
+  instance.findComponents = function (newEles) {
+
+    var adjListArray = [];
+    var current = cy.nodes().difference(newEles);
+    newEles.forEach(function (ele) {
+      var neighbors = ele.neighborhood().nodes().difference(current);
+      var listOfIndexes = [];
+      neighbors.forEach(function (neigbor) {
+        var index = newEles.indexOf(neigbor);
+        listOfIndexes.push(index);
+      });
+      adjListArray.push(listOfIndexes);
+    });
+
+    // Mark all the vertices as not visited 
+    var visited = [];
+    for (var v = 0; v < newEles.length; v++) {
+      visited.push(false);
+    }
+
+    var listOfComponents = [];
+
+    for (var v = 0; v < newEles.length; v++) {
+      var elesOfComponent = [];
+      if (visited[v] == false) {
+        // print all reachable vertices 
+        // from v 
+        this.DFSUtil(v, visited, adjListArray, newEles, elesOfComponent);
+        listOfComponents.push(elesOfComponent);
+      }
+    }
+
+    return listOfComponents;
+  };
+
+  instance.DFSUtil = function (v, visited, adjListArray, newEles, elesOfComponent) {
+    // Mark the current node as visited and print it 
+    visited[v] = true;
+    elesOfComponent.push(newEles[v]);
+    // Recur for all the vertices 
+    // adjacent to this vertex 
+    for (var i = 0; i < adjListArray[v].length; i++) {
+      if (!visited[adjListArray[v][i]]) this.DFSUtil(adjListArray[v][i], visited, adjListArray, newEles, elesOfComponent);
+    }
+  };
+
+  instance.nodeWithOneNeighbor = function (mainEle, hiddenEle) {
+    var quadrants = instance.checkOccupiedQuadrants(mainEle, hiddenEle);
+    var freeQuadrants = [];
+    for (var property in quadrants) {
+      if (quadrants[property] === "free") freeQuadrants.push(property);
+    }
+    //Can take values 1 and -1 and are used to place the hidden nodes in the random quadrant
+    var horizontalMult;
+    var verticalMult;
+    if (freeQuadrants.length > 0) {
+      if (freeQuadrants.length === 3) {
+        if (freeQuadrants.includes('first') && freeQuadrants.includes('second') && freeQuadrants.includes('third')) {
+          horizontalMult = -1;
+          verticalMult = -1;
+        } else if (freeQuadrants.includes('first') && freeQuadrants.includes('second') && freeQuadrants.includes('fourth')) {
+          horizontalMult = 1;
+          verticalMult = -1;
+        } else if (freeQuadrants.includes('first') && freeQuadrants.includes('third') && freeQuadrants.includes('fourth')) {
+          horizontalMult = 1;
+          verticalMult = 1;
+        } else if (freeQuadrants.includes('second') && freeQuadrants.includes('third') && freeQuadrants.includes('fourth')) {
+          horizontalMult = -1;
+          verticalMult = 1;
+        }
+      } else {
+        //Randomly picks one quadrant from the free quadrants
+        var randomQuadrant = freeQuadrants[Math.floor(Math.random() * freeQuadrants.length)];
+
+        if (randomQuadrant === "first") {
+          horizontalMult = 1;
+          verticalMult = -1;
+        } else if (randomQuadrant === "second") {
+          horizontalMult = -1;
+          verticalMult = -1;
+        } else if (randomQuadrant === "third") {
+          horizontalMult = -1;
+          verticalMult = 1;
+        } else if (randomQuadrant === "fourth") {
+          horizontalMult = 1;
+          verticalMult = 1;
+        }
+      }
+    } else {
+      horizontalMult = 0;
+      verticalMult = 0;
+    }
+    //Change the position of hidden elements
+
+    var horizontalParam = instance.generateRandom(options.idealEdgeLength - options.offset, options.idealEdgeLength + options.offset, horizontalMult);
+    var verticalParam = instance.generateRandom(options.idealEdgeLength - options.offset, options.idealEdgeLength + options.offset, verticalMult);
+    var newCenterX = mainEle.position("x") + horizontalParam;
+    var newCenterY = mainEle.position("y") + verticalParam;
+    hiddenEle.position("x", newCenterX);
+    hiddenEle.position("y", newCenterY);
+  };
+
+  instance.nodeWithMultipleNeighbors = function (ele, neighbors) {
+    if (neighbors == null) {
+      var neighbors = ele.neighborhood().nodes(":visible");
+    }
+    var x = 0;
+    var y = 0;
+    var count = 0;
+    neighbors.forEach(function (ele1) {
+      x += ele1.position("x");
+      y += ele1.position("y");
+      count++;
+    });
+    x = x / count;
+    y = y / count;
+    var diffx = instance.generateRandom(0, options.offset / 2, 0);
+    var diffy = instance.generateRandom(0, options.offset / 2, 0);
+    ele.position("x", x + diffx);
+    ele.position("y", y + diffy);
+  };
+
+  instance.generateRandom = function (min, max, mult) {
+    var val = [-1, 1];
+    if (mult === 0) mult = val[Math.floor(Math.random() * val.length)];
+    return (Math.floor(Math.random() * (max - min + 1)) + min) * mult;
+  };
+
+  instance.checkOccupiedQuadrants = function (mainEle, hiddenEles) {
+    var visibleEles = mainEle.neighborhood().difference(hiddenEles).nodes();
+    var occupiedQuadrants = { first: "free", second: "free", third: "free", fourth: "free" };
+
+    visibleEles.forEach(function (ele) {
+      if (ele.data('class') != 'compartment' && ele.data('class') != 'complex') {
+        if (ele.position("x") < mainEle.position("x") && ele.position("y") < mainEle.position("y")) occupiedQuadrants.second = "occupied";else if (ele.position("x") > mainEle.position("x") && ele.position("y") < mainEle.position("y")) occupiedQuadrants.first = "occupied";else if (ele.position("x") < mainEle.position("x") && ele.position("y") > mainEle.position("y")) occupiedQuadrants.third = "occupied";else if (ele.position("x") > mainEle.position("x") && ele.position("y") > mainEle.position("y")) occupiedQuadrants.fourth = "occupied";
+      }
+    });
+    return occupiedQuadrants;
+  };
+
+  instance.packComponents = function (components) {
+    var currentCenter = generalUtils.getCenter(components);
+
+    var gridStep = 0;
+    var totalNodes = 0;
+    components.forEach(function (component) {
+      totalNodes += component.nodes.length;
+      component.nodes.forEach(function (node) {
+        gridStep += node.width + node.height;
+      });
+    });
+
+    gridStep = gridStep / (2 * totalNodes);
+    gridStep = Math.floor(gridStep * options.polyominoGridSizeFactor);
+
+    if (options.componentSpacing > 0) {
+      var spacingAmount = options.componentSpacing;
+      components.forEach(function (component) {
+        component.nodes.forEach(function (node) {
+          node.x = node.x - spacingAmount;
+          node.y = node.y - spacingAmount;
+          node.width = node.width + 2 * spacingAmount;
+          node.height = node.height + 2 * spacingAmount;
+        });
+      });
+    }
+    var gridWidth = 0,
+        gridHeight = 0;
+    var polyominos = [];
+    var globalX1 = 10000,
+        globalX2 = 0,
+        globalY1 = 10000,
+        globalY2 = 0;
+    //create polyominos for components
+    components.forEach(function (component, index) {
+      var x1 = 10000,
+          x2 = 0,
+          y1 = 10000,
+          y2 = 0;
+      component.nodes.forEach(function (node) {
+        if (node.x <= x1) x1 = node.x;
+        if (node.y <= y1) y1 = node.y;
+        if (node.x + node.width >= x2) x2 = node.x + node.width;
+        if (node.y + node.height >= y2) y2 = node.y + node.height;
+      });
+
+      component.edges.forEach(function (edge) {
+        if (edge.startX <= x1) x1 = edge.startX;
+        if (edge.startY <= y1) y1 = edge.startY;
+        if (edge.endX >= x2) x2 = edge.endX;
+        if (edge.endY >= y2) y2 = edge.endY;
+      });
+
+      if (x1 < globalX1) globalX1 = x1;
+      if (x2 > globalX2) globalX2 = x2;
+      if (y1 < globalY1) globalY1 = y1;
+      if (y2 > globalY2) globalY2 = y2;
+
+      gridWidth += x2 - x1;
+      gridHeight += y2 - y1;
+      var componentWidth = Math.floor((x2 - x1) / gridStep) + 1;
+      var componentHeight = Math.floor((y2 - y1) / gridStep) + 1;
+
+      var componentPolyomino = new polyominoPacking.Polyomino(componentWidth, componentHeight, index, x1, y1);
+
+      //fill nodes to polyomino cells
+      component.nodes.forEach(function (node) {
+        //top left cell of a node
+        var topLeftX = Math.floor((node.x - x1) / gridStep);
+        var topLeftY = Math.floor((node.y - y1) / gridStep);
+
+        //bottom right cell of a node
+        var bottomRightX = Math.floor((node.x + node.width - x1) / gridStep);
+        var bottomRightY = Math.floor((node.y + node.height - y1) / gridStep);
+
+        //all cells between topleft cell and bottom right cell should be occupied
+        for (var i = topLeftX; i <= bottomRightX; i++) {
+          for (var j = topLeftY; j <= bottomRightY; j++) {
+            componentPolyomino.grid[i][j] = true;
+          }
+        }
+      });
+
+      //fill cells where edges pass 
+      component.edges.forEach(function (edge) {
+        var p0 = {},
+            p1 = {};
+        p0.x = (edge.startX - x1) / gridStep;
+        p0.y = (edge.startY - y1) / gridStep;
+        p1.x = (edge.endX - x1) / gridStep;
+        p1.y = (edge.endY - y1) / gridStep;
+        //for every edge calculate the super cover 
+        var points = generalUtils.LineSuperCover(p0, p1);
+        points.forEach(function (point) {
+          var indexX = Math.floor(point.x);
+          var indexY = Math.floor(point.y);
+          if (indexX >= 0 && indexX < componentPolyomino.width && indexY >= 0 && indexY < componentPolyomino.height) {
+            componentPolyomino.grid[Math.floor(point.x)][Math.floor(point.y)] = true;
+          }
+        });
+      });
+
+      //update number of occupied cells in polyomino
+      for (var i = 0; i < componentPolyomino.width; i++) {
+        for (var j = 0; j < componentPolyomino.height; j++) {
+          if (componentPolyomino.grid[i][j]) componentPolyomino.numberOfOccupiredCells++;
+        }
+      }
+      polyominos.push(componentPolyomino);
+    });
+
+    var componentsCenter = new polyominoPacking.Point((globalX1 + globalX2) / 2, (globalY1 + globalY2) / 2);
+    var componentsCenteronGrid = new polyominoPacking.Point(Math.floor(componentsCenter.x / gridStep), Math.floor(componentsCenter.y / gridStep));
+    //order plyominos non-increasing order
+    polyominos.sort(function (a, b) {
+      var aSize = a.width * a.height;
+      var bSize = b.width * b.height;
+      // a should come before b in the sorted order
+      if (aSize > bSize) {
+        return -1;
+        // a should come after b in the sorted order
+      } else if (aSize < bSize) {
+        return 1;
+        // a and b are the same
+      } else {
+        return 0;
+      }
+    });
+
+    //main grid width and height is two the times the sum of all components widths and heights (worst case scenario)
+    gridWidth = Math.ceil(gridWidth * 2 / gridStep);
+    gridHeight = Math.ceil(gridHeight * 2 / gridStep);
+
+    //intialize the grid add 1 to avoid insufficient grid space due to divisin by 2 in calcuations
+    var mainGrid = new polyominoPacking.Grid(gridWidth + 1, gridHeight + 1);
+
+    //place first (biggest) polyomino in the center
+    mainGrid.placePolyomino(polyominos[0], mainGrid.center.x, mainGrid.center.y);
+
+    //for every polyomino try placeing it in first neighbors and calculate utility if none then second neighbor and so on..
+    for (var i = 1; i < polyominos.length; i++) {
+      var fullnessMax = 0;
+      var adjustedFullnessMax = 0;
+      var weigthFullnessAspectRatio = 0;
+      var minAspectRatioDiff = 1000000;
+      var placementFound = false;
+      var cells = [];
+      var resultLocation = {};
+      while (!placementFound) {
+
+        cells = mainGrid.getDirectNeighbors(cells, Math.ceil(Math.max(polyominos[i].width, polyominos[i].height) / 2));
+        cells.forEach(function (cell) {
+          if (mainGrid.tryPlacingPolyomino(polyominos[i], cell.x, cell.y)) {
+            placementFound = true;
+            var utilityValue = mainGrid.calculateUtilityOfPlacing(polyominos[i], cell.x, cell.y, options.desiredAspectRatio);
+            var cellChosen = false;
+            if (options.utilityFunction == 1) {
+              if (utilityValue.adjustedFullness > adjustedFullnessMax) {
+                cellChosen = true;
+              } else if (utilityValue.adjustedFullness == adjustedFullnessMax) {
+                if (utilityValue.fullness > fullnessMax) {
+                  cellChosen = true;
+                } else if (utilityValue.fullness == fullnessMax) {
+                  if (Math.abs(utilityValue.actualAspectRatio - options.desiredAspectRatio) <= minAspectRatioDiff) {
+                    cellChosen = true;
+                  }
+                }
+              }
+              if (cellChosen) {
+                adjustedFullnessMax = utilityValue.adjustedFullness;
+                minAspectRatioDiff = Math.abs(utilityValue.actualAspectRatio - options.desiredAspectRatio);
+                fullnessMax = utilityValue.fullness;
+                resultLocation.x = cell.x;
+                resultLocation.y = cell.y;
+              }
+            } else if (options.utilityFunction == 2) {
+              var aspectRatioDiff = Math.abs(utilityValue.actualAspectRatio - options.desiredAspectRatio);
+              var weightedUtility = utilityValue.fullness * .5 + (1 - aspectRatioDiff / Math.max(utilityValue.actualAspectRatio, options.desiredAspectRatio) * .5);
+              if (weightedUtility > weigthFullnessAspectRatio) {
+                weigthFullnessAspectRatio = weightedUtility;
+                resultLocation.x = cell.x;
+                resultLocation.y = cell.y;
+              }
+            }
+          }
+        });
+      }
+
+      mainGrid.placePolyomino(polyominos[i], resultLocation.x, resultLocation.y);
+    }
+
+    //sort polyominos according to index of input to return correct output order
+    polyominos.sort(function (a, b) {
+      if (a.index < b.index) {
+        return -1;
+      } else if (a.index > b.index) {
+        return 1;
+      } else {
+        return 0;
+      }
+    });
+
+    var packingResult = {};
+    packingResult.shifts = [];
+
+    /*  var shiftX = componentsCenter.x - ((mainGrid.center.x - mainGrid.occupiedRectangle.x1)*gridStep); 
+     var shiftY = componentsCenter.y - ((mainGrid.center.y - mainGrid.occupiedRectangle.y1)*gridStep); 
+     var occupiedCenterX = Math.floor((mainGrid.occupiedRectangle.x1 + mainGrid.occupiedRectangle.x2)/2);
+     var occupiedCenterY = Math.floor((mainGrid.occupiedRectangle.y1 + mainGrid.occupiedRectangle.y2)/2); */
+    var rectCenter = mainGrid.occupiedRectangle.center();
+
+    var renderedCenter = new Point(rectCenter.x * gridStep, rectCenter.y * gridStep);
+
+    var centerShift = renderedCenter.diff(currentCenter);
+
+    polyominos.forEach(function (pol) {
+      var dx = (pol.location.x - pol.center.x - mainGrid.occupiedRectangle.x1) * gridStep - pol.leftMostCoord + centerShift.x; //+shiftX;
+      var dy = (pol.location.y - pol.center.y - mainGrid.occupiedRectangle.y1) * gridStep - pol.topMostCoord + centerShift.y; // + shiftY;
+      //var dx = (pol.location.x -occupiedCenterX) * gridStep + componentsCenter.x- pol.leftMostCoord;//+shiftX;
+      //var dy = (pol.location.y -occupiedCenterY) * gridStep + componentsCenter.y-pol.topMostCoord;// + shiftY;
+      packingResult.shifts.push({ dx: dx, dy: dy });
+    });
+
+    packingResult.aspectRatio = Math.round((mainGrid.occupiedRectangle.x2 - mainGrid.occupiedRectangle.x1 + 1) / (mainGrid.occupiedRectangle.y2 - mainGrid.occupiedRectangle.y1 + 1) * 1e2) / 1e2;
+    packingResult.fullness = Math.round(mainGrid.numberOfOccupiredCells / ((mainGrid.occupiedRectangle.x2 - mainGrid.occupiedRectangle.x1 + 1) * (mainGrid.occupiedRectangle.y2 - mainGrid.occupiedRectangle.y1 + 1)) * 100 * 1e2) / 1e2;
+
+    if (packingResult.aspectRatio > options.desiredAspectRatio) {
+      var mainGridWidth = mainGrid.occupiedRectangle.x2 - mainGrid.occupiedRectangle.x1 + 1;
+      packingResult.adjustedFullness = Math.round(mainGrid.numberOfOccupiredCells / (mainGridWidth * (mainGridWidth / options.desiredAspectRatio)) * 100 * 1e2) / 1e2;
+      // height = width / desiredAspectRatio;
+    } else {
+
+      var mainGridheight = mainGrid.occupiedRectangle.y2 - mainGrid.occupiedRectangle.y1 + 1;
+      packingResult.adjustedFullness = Math.round(mainGrid.numberOfOccupiredCells / (mainGridheight * options.desiredAspectRatio * mainGridheight) * 100 * 1e2) / 1e2;
+
+      // width = height * desiredAspectRatio;
+    }
+
+    return packingResult;
+  };
+
+  return instance;
+};
+
+module.exports = layoutUtilities;
+
+/***/ }),
+/* 3 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+var __WEBPACK_AMD_DEFINE_RESULT__;
+
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+;
+(function () {
+  'use strict';
+
+  // registers the extension on a cytoscape lib ref
+
+  var register = function register(cytoscape) {
+
+    if (!cytoscape) {
+      return;
+    } // can't register if cytoscape unspecified
+
+    var options = {
+      idealEdgeLength: 50,
+      offset: 20,
+      desiredAspectRatio: 1,
+      polyominoGridSizeFactor: 1,
+      utilityFunction: 1, // Maximize adjusted Fullness   2: maximizes weighted function of fullness and aspect ratio
+      componentSpacing: 30
+    };
+
+    /*  function extend(defaults, options) {
+       var obj = {};
+        for (var i in defaults) {
+         obj[i] = defaults[i];
+       }
+        for (var i in options) {
+         if(i == "desiredAspectRatio"){
+           var value = options[i];
+            if(!isNaN(value))
+            {
+               if(value >= 0 && value <= 20){
+                 obj[i] = options[i];
+               }else if(value < 0){
+                 obj[i] = 0
+               }else{
+                 obj[i] = 20
+               }
+            }
+         }else{
+           obj[i] = options[i];
+         }
+        }
+        return obj;
+      }; */
+    var layoutUtilities = __webpack_require__(2);
+
+    cytoscape('core', 'layoutUtilities', function (opts) {
+      var cy = this;
+
+      // If 'get' is given as the param then return the extension instance
+      if (opts === 'get') {
+        return getScratch(cy).instance;
+      }
+
+      /**
+      * Deep copy or merge objects - replacement for jQuery deep extend
+      * Taken from http://youmightnotneedjquery.com/#deep_extend
+      * and bug related to deep copy of Arrays is fixed.
+      * Usage:Object.extend({}, objA, objB)
+      */
+      function extendOptions(out) {
+        out = out || {};
+
+        for (var i = 1; i < arguments.length; i++) {
+          var obj = arguments[i];
+
+          if (!obj) continue;
+
+          for (var key in obj) {
+            if (obj.hasOwnProperty(key)) {
+              if (Array.isArray(obj[key])) {
+                out[key] = obj[key].slice();
+              } else if (_typeof(obj[key]) === 'object') {
+                out[key] = extendOptions(out[key], obj[key]);
+              } else {
+                out[key] = obj[key];
+              }
+            }
+          }
+        }
+
+        return out;
+      };
+
+      options = extendOptions({}, options, opts);
+
+      function getScratch(eleOrCy) {
+        if (!eleOrCy.scratch("_layoutUtilities")) {
+          eleOrCy.scratch("_layoutUtilities", {});
+        }
+
+        return eleOrCy.scratch("_layoutUtilities");
+      }
+
+      // create a view utilities instance
+      var instance = layoutUtilities(cy, options);
+
+      // set the instance on the scratch pad
+      getScratch(cy).instance = instance;
+
+      if (!getScratch(cy).initialized) {
+        getScratch(cy).initialized = true;
+
+        var shiftKeyDown = false;
+        document.addEventListener('keydown', function (event) {
+          if (event.key == "Shift") {
+            shiftKeyDown = true;
+          }
+        });
+        document.addEventListener('keyup', function (event) {
+          if (event.key == "Shift") {
+            shiftKeyDown = false;
+          }
+        });
+        //Select the desired neighbors after taphold-and-free
+        /*  cy.on('taphold', 'node', function(event){
+           var target = event.target || event.cyTarget;
+           var tapheld = false;
+           var neighborhood;
+           var timeout = setTimeout(function(){
+             if(shiftKeyDown){
+               cy.elements().unselect();
+               neighborhood = options.neighbor(target);
+               if(neighborhood)
+                 neighborhood.select();
+               target.lock();
+               tapheld = true;
+             }
+           }, options.neighborSelectTime - 500);
+           cy.on('free', 'node', function(){
+             var targetTapheld = event.target || event.cyTarget;
+             if(target == targetTapheld && tapheld === true){
+               tapheld = false;
+               if(neighborhood)
+                 neighborhood.select();
+               target.unlock();
+             }
+             else{
+               clearTimeout(timeout);
+             }
+           });
+           cy.on('drag', 'node', function(){
+             var targetDragged = event.target || event.cyTarget;
+             if(target == targetDragged && tapheld === false){
+               clearTimeout(timeout);
+             }
+           })
+         }); */
+      }
+
+      // return the instance of extension
+      return getScratch(cy).instance;
+    });
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    // expose as a commonjs module
+    module.exports = register;
+  }
+
+  if (true) {
+    // expose as an amd/requirejs module
+    !(__WEBPACK_AMD_DEFINE_RESULT__ = function () {
+      return register;
+    }.call(exports, __webpack_require__, exports, module),
+				__WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+  }
+
+  if (typeof cytoscape !== 'undefined') {
+    // expose to global cytoscape (i.e. window.cytoscape)
+    register(cytoscape);
+  }
+})();
+
+/***/ })
+/******/ ]);
+});

--- a/cytoscape-layout-utilities.js
+++ b/cytoscape-layout-utilities.js
@@ -531,17 +531,17 @@ var layoutUtilities = function layoutUtilities(cy, options) {
      polyominoGridSizeFactor : 1,
      utilityFunction : 1
    };
-    function extend(defaults, options) {
+     function extend(defaults, options) {
      var obj = {};
-      for (var i in defaults) {
+       for (var i in defaults) {
        obj[i] = defaults[i];
      }
-      for (var i in options) {      
+       for (var i in options) {      
        obj[i] = options[i];
      }
-      return obj;
+       return obj;
    };
-    options = extend(defaults, options); */
+     options = extend(defaults, options); */
   var instance = {};
 
   instance.placeHiddenNodes = function (mainEles) {
@@ -1115,10 +1115,10 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
 
     /*  function extend(defaults, options) {
        var obj = {};
-        for (var i in defaults) {
+         for (var i in defaults) {
          obj[i] = defaults[i];
        }
-        for (var i in options) {
+         for (var i in options) {
          if(i == "desiredAspectRatio"){
            var value = options[i];
             if(!isNaN(value))
@@ -1134,8 +1134,8 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
          }else{
            obj[i] = options[i];
          }
-        }
-        return obj;
+         }
+         return obj;
       }; */
     var layoutUtilities = __webpack_require__(2);
 

--- a/cytoscape-layout-utilities.js
+++ b/cytoscape-layout-utilities.js
@@ -272,7 +272,7 @@ var Grid = function () {
             });
         });
         this.center = new Point(Math.floor(this.stepWidth / 2), Math.floor(this.stepHeight / 2));
-        this.occupiedRectangle = new BoundingRectangle(Number.MAX_VALUE, Number.MAX_VALUE, Number.MIN_VALUE, Number.MIN_VALUE); // the bounding rectanble of the occupied cells in the grid
+        this.occupiedRectangle = new BoundingRectangle(Number.MAX_VALUE, Number.MAX_VALUE, -Number.MAX_VALUE, -Number.MAX_VALUE); // the bounding rectanble of the occupied cells in the grid
         this.numberOfOccupiredCells = 0;
     }
 
@@ -631,9 +631,9 @@ generalUtils.getCenter = function (components) {
     };
   }, {
     left: Number.MAX_VALUE,
-    right: Number.MIN_VALUE,
+    right: -Number.MAX_VALUE,
     top: Number.MAX_VALUE,
-    bottom: Number.MIN_VALUE
+    bottom: -Number.MAX_VALUE
   });
 
   return new Point((bounds.left + bounds.right) / 2, (bounds.top + bounds.bottom) / 2);
@@ -764,9 +764,9 @@ var layoutUtilities = function layoutUtilities(cy, options) {
 
   instance.disconnectedNodes = function (components) {
     var leftX = Number.MAX_VALUE;
-    var rightX = Number.MIN_VALUE;
+    var rightX = -Number.MAX_VALUE;
     var topY = Number.MAX_VALUE;
-    var bottomY = Number.MIN_VALUE;
+    var bottomY = -Number.MAX_VALUE;
     // Check the x and y limits of all hidden elements and store them in the variables above
     cy.nodes(':visible').forEach(function (node) {
       var halfWidth = node.outerWidth() / 2;
@@ -975,7 +975,7 @@ var layoutUtilities = function layoutUtilities(cy, options) {
    * @param { { nodes: any[] }[] } components
    * @param { { dx: number, dy: number }[] } shifts
    */
-  function calculateShiftedCenter(components, shifts) {
+  function calculatePackingCenter(components, shifts) {
     components.forEach(function (component, index) {
       component.nodes.forEach(function (node) {
         node.x += shifts[index].dx;
@@ -991,8 +991,6 @@ var layoutUtilities = function layoutUtilities(cy, options) {
    */
   instance.packComponents = function (components) {
     var currentCenter = generalUtils.getCenter(components);
-
-    console.log('current center: ', currentCenter);
 
     var gridStep = 0;
     var totalNodes = 0;
@@ -1022,15 +1020,15 @@ var layoutUtilities = function layoutUtilities(cy, options) {
     /** @type { Polyomino[] } */
     var polyominos = [];
     var globalX1 = Number.MAX_VALUE,
-        globalX2 = Number.MIN_VALUE,
+        globalX2 = -Number.MAX_VALUE,
         globalY1 = Number.MAX_VALUE,
-        globalY2 = Number.MIN_VALUE;
+        globalY2 = -Number.MAX_VALUE;
     //create polyominos for components
     components.forEach(function (component, index) {
       var x1 = Number.MAX_VALUE,
-          x2 = Number.MIN_VALUE,
+          x2 = -Number.MAX_VALUE,
           y1 = Number.MAX_VALUE,
-          y2 = Number.MIN_VALUE;
+          y2 = -Number.MAX_VALUE;
       component.nodes.forEach(function (node) {
         if (node.x <= x1) x1 = node.x;
         if (node.y <= y1) y1 = node.y;
@@ -1207,9 +1205,9 @@ var layoutUtilities = function layoutUtilities(cy, options) {
     });
 
     // Calculate what would be the center of the packed layout
-    var shiftedCenter = calculateShiftedCenter(components, packingResult.shifts);
+    var packingCenter = calculatePackingCenter(components, packingResult.shifts);
     // Calculate the neccessary  additional shift to re-center
-    var centerShift = shiftedCenter.diff(currentCenter);
+    var centerShift = packingCenter.diff(currentCenter);
 
     // Add the center shift
     var _iteratorNormalCompletion = true;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5684,7 +5684,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5705,12 +5706,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5725,17 +5728,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5852,7 +5858,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5864,6 +5871,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5878,6 +5886,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5885,12 +5894,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5909,6 +5920,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5989,7 +6001,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6001,6 +6014,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6086,7 +6100,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6122,6 +6137,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6141,6 +6157,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6184,12 +6201,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/core/general-utils.js
+++ b/src/core/general-utils.js
@@ -1,5 +1,6 @@
 var generalUtils = {};
 var polyominoPacking = require('./polyomino-packing');
+const { Point } = require('./polyomino-packing');
 
 
 //a function to remove duplicate object in array
@@ -41,6 +42,55 @@ generalUtils.LineSuperCover = function(p0,p1){
   }
   return points;
 };
+
+/**
+ * finds the current center of components
+ * @param { Array } components 
+ */
+generalUtils.getCenter = function(components) {
+  // In case the platform doesn't have flatMap function
+  if (typeof Array.prototype['flatMap'] === 'undefined') {
+    Array.prototype['flatMap'] = function(f) {
+      const concat = (x, y) => x.concat(y);
+      const flatMap = (f, xs) => xs.map(f).reduce(concat, []);
+
+      return flatMap(f, this);
+    }
+  }
+
+  let bounds = components.flatMap(component => component.nodes)
+  .map(node => {
+    return {
+      left: node.x,
+      top: node.y,
+      right: node.x + node.width,
+      bottom: node.y + node.height,
+    };
+  })
+  .reduce((bounds, currNode) => {
+    if (currNode.left < bounds.left) {
+      bounds.left = currNode.left;
+    }
+    if (currNode.right > bounds.right) {
+      bounds.right = currNode.right;
+    }
+    if (currNode.top < bounds.top) {
+      bounds.top = currNode.top;
+    }
+    if (currNode.bottom > bounds.bottom) {
+      bounds.bottom = currNode.bottom;
+    }
+
+    return bounds;
+  }, { 
+    left: Number.MAX_VALUE, 
+    right: Number.MIN_VALUE,
+    top: Number.MAX_VALUE, 
+    bottom: Number.MIN_VALUE
+  });
+
+  return new Point((bounds.left + bounds.right) / 2, (bounds.top + bounds.bottom) / 2);
+}
 
 module.exports = generalUtils;
   

--- a/src/core/general-utils.js
+++ b/src/core/general-utils.js
@@ -55,7 +55,7 @@ generalUtils.getCenter = function (components) {
       const flatMap = (f, xs) => xs.map(f).reduce(concat, []);
 
       return flatMap(f, this);
-    }
+    };
   }
 
   let bounds = components.flatMap(component => component.nodes)
@@ -82,7 +82,6 @@ generalUtils.getCenter = function (components) {
     });
 
   return new Point((bounds.left + bounds.right) / 2, (bounds.top + bounds.bottom) / 2);
-}
+};
 
 module.exports = generalUtils;
-

--- a/src/core/general-utils.js
+++ b/src/core/general-utils.js
@@ -4,41 +4,41 @@ const { Point } = require('./polyomino-packing');
 
 
 //a function to remove duplicate object in array
-generalUtils.uniqueArray =  function( ar ) {
-    var j = {};  
-    ar.forEach( function(v) {
-      j[v+ '::' + typeof v] = v;
-    });  
-    return Object.keys(j).map(function(v){
-      return j[v];
-    });
+generalUtils.uniqueArray = function (ar) {
+  var j = {};
+  ar.forEach(function (v) {
+    j[v + '::' + typeof v] = v;
+  });
+  return Object.keys(j).map(function (v) {
+    return j[v];
+  });
 };
 
 //a function to determine the grid cells where a line between point p0 and p1 pass through
-generalUtils.LineSuperCover = function(p0,p1){
-  var dx = p1.x-p0.x, dy = p1.y-p0.y;
+generalUtils.LineSuperCover = function (p0, p1) {
+  var dx = p1.x - p0.x, dy = p1.y - p0.y;
   var nx = Math.floor(Math.abs(dx)), ny = Math.floor(Math.abs(dy));
-  var sign_x = dx > 0? 1 : -1, sign_y = dy > 0? 1 : -1;
+  var sign_x = dx > 0 ? 1 : -1, sign_y = dy > 0 ? 1 : -1;
 
   var p = new polyominoPacking.Point(p0.x, p0.y);
   var points = [new polyominoPacking.Point(p.x, p.y)];
   for (var ix = 0, iy = 0; ix < nx || iy < ny;) {
-      if ((0.5+ix) / nx == (0.5+iy) / ny) {
-          // next step is diagonal
-          p.x += sign_x;
-          p.y += sign_y;
-          ix++;
-          iy++;
-      } else if ((0.5+ix) / nx < (0.5+iy) / ny) {
-          // next step is horizontal
-          p.x += sign_x;
-          ix++;
-      } else {
-          // next step is vertical
-          p.y += sign_y;
-          iy++;
-      }
-      points.push(new polyominoPacking.Point(p.x, p.y));
+    if ((0.5 + ix) / nx == (0.5 + iy) / ny) {
+      // next step is diagonal
+      p.x += sign_x;
+      p.y += sign_y;
+      ix++;
+      iy++;
+    } else if ((0.5 + ix) / nx < (0.5 + iy) / ny) {
+      // next step is horizontal
+      p.x += sign_x;
+      ix++;
+    } else {
+      // next step is vertical
+      p.y += sign_y;
+      iy++;
+    }
+    points.push(new polyominoPacking.Point(p.x, p.y));
   }
   return points;
 };
@@ -47,10 +47,10 @@ generalUtils.LineSuperCover = function(p0,p1){
  * finds the current center of components
  * @param { Array } components 
  */
-generalUtils.getCenter = function(components) {
+generalUtils.getCenter = function (components) {
   // In case the platform doesn't have flatMap function
   if (typeof Array.prototype['flatMap'] === 'undefined') {
-    Array.prototype['flatMap'] = function(f) {
+    Array.prototype['flatMap'] = function (f) {
       const concat = (x, y) => x.concat(y);
       const flatMap = (f, xs) => xs.map(f).reduce(concat, []);
 
@@ -59,38 +59,38 @@ generalUtils.getCenter = function(components) {
   }
 
   let bounds = components.flatMap(component => component.nodes)
-  .map(node => {
-    return {
-      left: node.x,
-      top: node.y,
-      right: node.x + node.width,
-      bottom: node.y + node.height,
-    };
-  })
-  .reduce((bounds, currNode) => {
-    if (currNode.left < bounds.left) {
-      bounds.left = currNode.left;
-    }
-    if (currNode.right > bounds.right) {
-      bounds.right = currNode.right;
-    }
-    if (currNode.top < bounds.top) {
-      bounds.top = currNode.top;
-    }
-    if (currNode.bottom > bounds.bottom) {
-      bounds.bottom = currNode.bottom;
-    }
+    .map(node => {
+      return {
+        left: node.x,
+        top: node.y,
+        right: node.x + node.width,
+        bottom: node.y + node.height,
+      };
+    })
+    .reduce((bounds, currNode) => {
+      if (currNode.left < bounds.left) {
+        bounds.left = currNode.left;
+      }
+      if (currNode.right > bounds.right) {
+        bounds.right = currNode.right;
+      }
+      if (currNode.top < bounds.top) {
+        bounds.top = currNode.top;
+      }
+      if (currNode.bottom > bounds.bottom) {
+        bounds.bottom = currNode.bottom;
+      }
 
-    return bounds;
-  }, { 
-    left: Number.MAX_VALUE, 
-    right: Number.MIN_VALUE,
-    top: Number.MAX_VALUE, 
-    bottom: Number.MIN_VALUE
-  });
+      return bounds;
+    }, {
+      left: Number.MAX_VALUE,
+      right: Number.MIN_VALUE,
+      top: Number.MAX_VALUE,
+      bottom: Number.MIN_VALUE
+    });
 
   return new Point((bounds.left + bounds.right) / 2, (bounds.top + bounds.bottom) / 2);
 }
 
 module.exports = generalUtils;
-  
+

--- a/src/core/general-utils.js
+++ b/src/core/general-utils.js
@@ -63,8 +63,8 @@ generalUtils.getCenter = function (components) {
     .map(node => ({
       left: node.x,
       top: node.y,
-      right: node.x + node.width,
-      bottom: node.y + node.height,
+      right: node.x + node.width - 1,
+      bottom: node.y + node.height - 1,
     }))
     .reduce((bounds, currNode) => ({
         left: Math.min(currNode.left, bounds.left),

--- a/src/core/general-utils.js
+++ b/src/core/general-utils.js
@@ -73,9 +73,9 @@ generalUtils.getCenter = function (components) {
         bottom: Math.max(currNode.bottom, bounds.bottom)
     }), {
       left: Number.MAX_VALUE,
-      right: Number.MIN_VALUE,
+      right: -Number.MAX_VALUE,
       top: Number.MAX_VALUE,
-      bottom: Number.MIN_VALUE
+      bottom: -Number.MAX_VALUE
     });
 
   return new Point((bounds.left + bounds.right) / 2, (bounds.top + bounds.bottom) / 2);

--- a/src/core/general-utils.js
+++ b/src/core/general-utils.js
@@ -59,30 +59,22 @@ generalUtils.getCenter = function (components) {
   }
 
   let bounds = components.flatMap(component => component.nodes)
-    .map(node => {
-      return {
-        left: node.x,
-        top: node.y,
-        right: node.x + node.width,
-        bottom: node.y + node.height,
-      };
-    })
-    .reduce((bounds, currNode) => {
-      if (currNode.left < bounds.left) {
-        bounds.left = currNode.left;
-      }
-      if (currNode.right > bounds.right) {
-        bounds.right = currNode.right;
-      }
-      if (currNode.top < bounds.top) {
-        bounds.top = currNode.top;
-      }
-      if (currNode.bottom > bounds.bottom) {
-        bounds.bottom = currNode.bottom;
-      }
-
-      return bounds;
-    }, {
+    .map(node => ({
+      left: node.x,
+      top: node.y,
+      right: node.x + node.width,
+      bottom: node.y + node.height,
+    }))
+    .reduce((bounds, currNode) => ({
+        left: currNode.left < bounds.left ? 
+          currNode.left : bounds.left,
+        right: currNode.right > bounds.right ? 
+          currNode.right : bounds.right,
+        top: currNode.top < bounds.top ? 
+          currNode.top : bounds.top,
+        bottom: currNode.bottom > bounds.bottom ? 
+          currNode.bottom : bounds.bottom,
+    }), {
       left: Number.MAX_VALUE,
       right: Number.MIN_VALUE,
       top: Number.MAX_VALUE,

--- a/src/core/general-utils.js
+++ b/src/core/general-utils.js
@@ -58,6 +58,7 @@ generalUtils.getCenter = function (components) {
     };
   }
 
+  // @ts-ignore
   let bounds = components.flatMap(component => component.nodes)
     .map(node => ({
       left: node.x,
@@ -66,14 +67,10 @@ generalUtils.getCenter = function (components) {
       bottom: node.y + node.height,
     }))
     .reduce((bounds, currNode) => ({
-        left: currNode.left < bounds.left ? 
-          currNode.left : bounds.left,
-        right: currNode.right > bounds.right ? 
-          currNode.right : bounds.right,
-        top: currNode.top < bounds.top ? 
-          currNode.top : bounds.top,
-        bottom: currNode.bottom > bounds.bottom ? 
-          currNode.bottom : bounds.bottom,
+        left: Math.min(currNode.left, bounds.left),
+        right: Math.max(currNode.right, bounds.right),
+        top: Math.min(currNode.top, bounds.top),
+        bottom: Math.max(currNode.bottom, bounds.bottom)
     }), {
       left: Number.MAX_VALUE,
       right: Number.MIN_VALUE,

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -15,38 +15,38 @@
       desiredAspectRatio: 1,
       polyominoGridSizeFactor: 1,
       utilityFunction: 1,  // Maximize adjusted Fullness   2: maximizes weighted function of fullness and aspect ratio
-      componentSpacing : 30
+      componentSpacing: 30
     };
 
 
-   /*  function extend(defaults, options) {
-      var obj = {};
-
-      for (var i in defaults) {
-        obj[i] = defaults[i];
-      }
-
-      for (var i in options) {
-        if(i == "desiredAspectRatio"){
-          var value = options[i];
-           if(!isNaN(value))
-           {
-              if(value >= 0 && value <= 20){
-                obj[i] = options[i];
-              }else if(value < 0){
-                obj[i] = 0
-              }else{
-                obj[i] = 20
-              }
-           }
-        }else{
-          obj[i] = options[i];
-        }
-
-      }
-
-      return obj;
-     }; */
+    /*  function extend(defaults, options) {
+       var obj = {};
+ 
+       for (var i in defaults) {
+         obj[i] = defaults[i];
+       }
+ 
+       for (var i in options) {
+         if(i == "desiredAspectRatio"){
+           var value = options[i];
+            if(!isNaN(value))
+            {
+               if(value >= 0 && value <= 20){
+                 obj[i] = options[i];
+               }else if(value < 0){
+                 obj[i] = 0
+               }else{
+                 obj[i] = 20
+               }
+            }
+         }else{
+           obj[i] = options[i];
+         }
+ 
+       }
+ 
+       return obj;
+      }; */
     var layoutUtilities = require("./layout-utilities");
 
     cytoscape('core', 'layoutUtilities', function (opts) {
@@ -56,7 +56,7 @@
       if (opts === 'get') {
         return getScratch(cy).instance;
       }
-      
+
       /**
       * Deep copy or merge objects - replacement for jQuery deep extend
       * Taken from http://youmightnotneedjquery.com/#deep_extend
@@ -87,7 +87,7 @@
 
         return out;
       };
-      
+
       options = extendOptions({}, options, opts);
 
       function getScratch(eleOrCy) {
@@ -97,7 +97,7 @@
 
         return eleOrCy.scratch("_layoutUtilities");
       }
-      
+
       // create a view utilities instance
       var instance = layoutUtilities(cy, options);
 
@@ -109,50 +109,50 @@
         getScratch(cy).initialized = true;
 
         var shiftKeyDown = false;
-        document.addEventListener('keydown', function(event){
-          if(event.key == "Shift") {
+        document.addEventListener('keydown', function (event) {
+          if (event.key == "Shift") {
             shiftKeyDown = true;
           }
         });
-        document.addEventListener('keyup', function(event){
-          if(event.key == "Shift") {
+        document.addEventListener('keyup', function (event) {
+          if (event.key == "Shift") {
             shiftKeyDown = false;
           }
         });
         //Select the desired neighbors after taphold-and-free
-       /*  cy.on('taphold', 'node', function(event){
-          var target = event.target || event.cyTarget;
-          var tapheld = false;
-          var neighborhood;
-          var timeout = setTimeout(function(){
-            if(shiftKeyDown){
-              cy.elements().unselect();
-              neighborhood = options.neighbor(target);
-              if(neighborhood)
-                neighborhood.select();
-              target.lock();
-              tapheld = true;
-            }
-          }, options.neighborSelectTime - 500);
-          cy.on('free', 'node', function(){
-            var targetTapheld = event.target || event.cyTarget;
-            if(target == targetTapheld && tapheld === true){
-              tapheld = false;
-              if(neighborhood)
-                neighborhood.select();
-              target.unlock();
-            }
-            else{
-              clearTimeout(timeout);
-            }
-          });
-          cy.on('drag', 'node', function(){
-            var targetDragged = event.target || event.cyTarget;
-            if(target == targetDragged && tapheld === false){
-              clearTimeout(timeout);
-            }
-          })
-        }); */
+        /*  cy.on('taphold', 'node', function(event){
+           var target = event.target || event.cyTarget;
+           var tapheld = false;
+           var neighborhood;
+           var timeout = setTimeout(function(){
+             if(shiftKeyDown){
+               cy.elements().unselect();
+               neighborhood = options.neighbor(target);
+               if(neighborhood)
+                 neighborhood.select();
+               target.lock();
+               tapheld = true;
+             }
+           }, options.neighborSelectTime - 500);
+           cy.on('free', 'node', function(){
+             var targetTapheld = event.target || event.cyTarget;
+             if(target == targetTapheld && tapheld === true){
+               tapheld = false;
+               if(neighborhood)
+                 neighborhood.select();
+               target.unlock();
+             }
+             else{
+               clearTimeout(timeout);
+             }
+           });
+           cy.on('drag', 'node', function(){
+             var targetDragged = event.target || event.cyTarget;
+             if(target == targetDragged && tapheld === false){
+               clearTimeout(timeout);
+             }
+           })
+         }); */
       }
 
       // return the instance of extension

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,4 +1,3 @@
-;
 (function () {
   'use strict';
 
@@ -86,7 +85,7 @@
         }
 
         return out;
-      };
+      }
 
       options = extendOptions({}, options, opts);
 

--- a/src/core/layout-utilities.js
+++ b/src/core/layout-utilities.js
@@ -1,6 +1,7 @@
 
 var generalUtils = require('./general-utils.js');
 var polyominoPacking = require('./polyomino-packing');
+const { Point } = require('./polyomino-packing');
 var layoutUtilities = function (cy, options) {
 
  /*  var defaults = {
@@ -361,6 +362,7 @@ var layoutUtilities = function (cy, options) {
 
  
   instance.packComponents = function(components){
+    let currentCenter = generalUtils.getCenter(components);
 
     var gridStep = 0;
     var totalNodes = 0;
@@ -568,10 +570,15 @@ var layoutUtilities = function (cy, options) {
   var shiftY = componentsCenter.y - ((mainGrid.center.y - mainGrid.occupiedRectangle.y1)*gridStep); 
   var occupiedCenterX = Math.floor((mainGrid.occupiedRectangle.x1 + mainGrid.occupiedRectangle.x2)/2);
   var occupiedCenterY = Math.floor((mainGrid.occupiedRectangle.y1 + mainGrid.occupiedRectangle.y2)/2); */
+    let rectCenter = mainGrid.occupiedRectangle.center();
+
+    let renderedCenter = new Point(rectCenter.x * gridStep, rectCenter.y * gridStep);
+    
+    let centerShift = renderedCenter.diff(currentCenter);
 
     polyominos.forEach(function(pol){
-      var dx = (pol.location.x - pol.center.x - mainGrid.occupiedRectangle.x1) * gridStep - pol.leftMostCoord ;//+shiftX;
-      var dy = (pol.location.y -pol.center.y - mainGrid.occupiedRectangle.y1) * gridStep - pol.topMostCoord;// + shiftY;
+      var dx = (pol.location.x - pol.center.x - mainGrid.occupiedRectangle.x1) * gridStep - pol.leftMostCoord + centerShift.x;//+shiftX;
+      var dy = (pol.location.y -pol.center.y - mainGrid.occupiedRectangle.y1) * gridStep - pol.topMostCoord + centerShift.y;// + shiftY;
       //var dx = (pol.location.x -occupiedCenterX) * gridStep + componentsCenter.x- pol.leftMostCoord;//+shiftX;
       //var dy = (pol.location.y -occupiedCenterY) * gridStep + componentsCenter.y-pol.topMostCoord;// + shiftY;
       packingResult.shifts.push({dx: dx, dy: dy});

--- a/src/core/layout-utilities.js
+++ b/src/core/layout-utilities.js
@@ -117,9 +117,9 @@ var layoutUtilities = function (cy, options) {
 
   instance.disconnectedNodes = function (components) {
     var leftX = Number.MAX_VALUE;
-    var rightX = Number.MIN_VALUE;
+    var rightX = -Number.MAX_VALUE;
     var topY = Number.MAX_VALUE;
-    var bottomY = Number.MIN_VALUE;
+    var bottomY = -Number.MAX_VALUE;
     // Check the x and y limits of all hidden elements and store them in the variables above
     cy.nodes(':visible').forEach(function (node) {
       var halfWidth = node.outerWidth() / 2;
@@ -352,7 +352,7 @@ var layoutUtilities = function (cy, options) {
    * @param { { nodes: any[] }[] } components
    * @param { { dx: number, dy: number }[] } shifts
    */
-  function calculateShiftedCenter(components, shifts) {
+  function calculatePackingCenter(components, shifts) {
     components.forEach((component, index) => {
         component.nodes.forEach(node => {
           node.x += shifts[index].dx;
@@ -366,7 +366,7 @@ var layoutUtilities = function (cy, options) {
   /**
    * @param { any[] } components 
    */
-  instance.packComponents = function (components) {
+  instance.packComponents = function (components) {    
     let currentCenter = generalUtils.getCenter(components);
     
     var gridStep = 0;
@@ -396,10 +396,10 @@ var layoutUtilities = function (cy, options) {
     var gridWidth = 0, gridHeight = 0;
     /** @type { Polyomino[] } */
     var polyominos = [];
-    var globalX1 = Number.MAX_VALUE, globalX2 = Number.MIN_VALUE, globalY1 = Number.MAX_VALUE, globalY2 = Number.MIN_VALUE;
+    var globalX1 = Number.MAX_VALUE, globalX2 = -Number.MAX_VALUE, globalY1 = Number.MAX_VALUE, globalY2 = -Number.MAX_VALUE;
     //create polyominos for components
     components.forEach(function (component, index) {
-      var x1 = Number.MAX_VALUE, x2 = Number.MIN_VALUE, y1 = Number.MAX_VALUE, y2 = Number.MIN_VALUE;
+      var x1 = Number.MAX_VALUE, x2 = -Number.MAX_VALUE, y1 = Number.MAX_VALUE, y2 = -Number.MAX_VALUE;
       component.nodes.forEach(function (node) {
         if (node.x <= x1) x1 = node.x;
         if (node.y <= y1) y1 = node.y;
@@ -578,9 +578,9 @@ var layoutUtilities = function (cy, options) {
     });
 
     // Calculate what would be the center of the packed layout
-    let shiftedCenter = calculateShiftedCenter(components, packingResult.shifts);
+    let packingCenter = calculatePackingCenter(components, packingResult.shifts);
     // Calculate the neccessary  additional shift to re-center
-    let centerShift = shiftedCenter.diff(currentCenter);
+    let centerShift = packingCenter.diff(currentCenter);
 
     // Add the center shift
     for (let shift of packingResult.shifts) {

--- a/src/core/layout-utilities.js
+++ b/src/core/layout-utilities.js
@@ -378,10 +378,10 @@ var layoutUtilities = function (cy, options) {
     }
     var gridWidth = 0, gridHeight = 0;
     var polyominos = [];
-    var globalX1 = 10000, globalX2 = 0, globalY1 = 10000, globalY2 = 0;
+    var globalX1 = Number.MAX_VALUE, globalX2 = Number.MIN_VALUE, globalY1 = Number.MAX_VALUE, globalY2 = Number.MIN_VALUE;
     //create polyominos for components
     components.forEach(function (component, index) {
-      var x1 = 10000, x2 = 0, y1 = 10000, y2 = 0;
+      var x1 = Number.MAX_VALUE, x2 = Number.MIN_VALUE, y1 = Number.MAX_VALUE, y2 = Number.MIN_VALUE;
       component.nodes.forEach(function (node) {
         if (node.x <= x1) x1 = node.x;
         if (node.y <= y1) y1 = node.y;
@@ -422,7 +422,6 @@ var layoutUtilities = function (cy, options) {
         for (var i = topLeftX; i <= bottomRightX; i++) {
           for (var j = topLeftY; j <= bottomRightY; j++) {
             componentPolyomino.grid[i][j] = true;
-
           }
         }
       });
@@ -455,6 +454,7 @@ var layoutUtilities = function (cy, options) {
       polyominos.push(componentPolyomino);
     });
 
+    // These variables are not used anywhere. Should be safe to remove
     var componentsCenter = new polyominoPacking.Point((globalX1 + globalX2) / 2, (globalY1 + globalY2) / 2);
     var componentsCenteronGrid = new polyominoPacking.Point(Math.floor(componentsCenter.x / gridStep), Math.floor(componentsCenter.y / gridStep));
     //order plyominos non-increasing order
@@ -482,8 +482,6 @@ var layoutUtilities = function (cy, options) {
 
     //place first (biggest) polyomino in the center
     mainGrid.placePolyomino(polyominos[0], mainGrid.center.x, mainGrid.center.y);
-
-
 
     //for every polyomino try placeing it in first neighbors and calculate utility if none then second neighbor and so on..
     for (var i = 1; i < polyominos.length; i++) {
@@ -558,11 +556,10 @@ var layoutUtilities = function (cy, options) {
     /*  var shiftX = componentsCenter.x - ((mainGrid.center.x - mainGrid.occupiedRectangle.x1)*gridStep); 
      var shiftY = componentsCenter.y - ((mainGrid.center.y - mainGrid.occupiedRectangle.y1)*gridStep); 
      var occupiedCenterX = Math.floor((mainGrid.occupiedRectangle.x1 + mainGrid.occupiedRectangle.x2)/2);
-     var occupiedCenterY = Math.floor((mainGrid.occupiedRectangle.y1 + mainGrid.occupiedRectangle.y2)/2); */
+     var occupiedCenterY = Math.floor((mainGrid.occupiedRectangle.y1 + mainGrid.occupiedRectangle.y2)/2); */7
+    // Calculate the difference between old center and new center
     let rectCenter = mainGrid.occupiedRectangle.center();
-
     let renderedCenter = new Point(rectCenter.x * gridStep, rectCenter.y * gridStep);
-
     let centerShift = renderedCenter.diff(currentCenter);
 
     polyominos.forEach(function (pol) {
@@ -581,10 +578,8 @@ var layoutUtilities = function (cy, options) {
       packingResult.adjustedFullness = Math.round((((mainGrid.numberOfOccupiredCells) / (mainGridWidth * (mainGridWidth / options.desiredAspectRatio)) * 100)) * 1e2) / 1e2;
       // height = width / desiredAspectRatio;
     } else {
-
       var mainGridheight = mainGrid.occupiedRectangle.y2 - mainGrid.occupiedRectangle.y1 + 1;
       packingResult.adjustedFullness = Math.round((((mainGrid.numberOfOccupiredCells) / ((mainGridheight * options.desiredAspectRatio) * mainGridheight)) * 100) * 1e2) / 1e2;
-
       // width = height * desiredAspectRatio;
     }
 

--- a/src/core/layout-utilities.js
+++ b/src/core/layout-utilities.js
@@ -4,29 +4,29 @@ var polyominoPacking = require('./polyomino-packing');
 const { Point } = require('./polyomino-packing');
 var layoutUtilities = function (cy, options) {
 
- /*  var defaults = {
-    idealEdgeLength : 50,
-    offset : 20,
-    desiredAspectRatio : 1,
-    polyominoGridSizeFactor : 1,
-    utilityFunction : 1
-  };
-
-  function extend(defaults, options) {
-    var obj = {};
-
-    for (var i in defaults) {
-      obj[i] = defaults[i];
-    }
-
-    for (var i in options) {      
-      obj[i] = options[i];
-    }
-
-    return obj;
-  };
-
-  options = extend(defaults, options); */
+  /*  var defaults = {
+     idealEdgeLength : 50,
+     offset : 20,
+     desiredAspectRatio : 1,
+     polyominoGridSizeFactor : 1,
+     utilityFunction : 1
+   };
+ 
+   function extend(defaults, options) {
+     var obj = {};
+ 
+     for (var i in defaults) {
+       obj[i] = defaults[i];
+     }
+ 
+     for (var i in options) {      
+       obj[i] = options[i];
+     }
+ 
+     return obj;
+   };
+ 
+   options = extend(defaults, options); */
   var instance = {};
 
   instance.placeHiddenNodes = function (mainEles) {
@@ -41,22 +41,22 @@ var layoutUtilities = function (cy, options) {
     });
   };
 
-  instance.placeNewNodes = function (eles){
+  instance.placeNewNodes = function (eles) {
     var components = this.findComponents(eles);
     var disconnectedComp = [];
-    for(var i =0; i< components.length ; i++){
+    for (var i = 0; i < components.length; i++) {
       var oneNeig = false;
       var multNeig = false;
       var mainEle;
       var multneighbors = [];
       var positioned = [];
-      var x =0;
+      var x = 0;
       var y = 0;
       var isPositioned = false;
-      for(var j=0; j<components[i].length ; j++){
+      for (var j = 0; j < components[i].length; j++) {
         var neighbors = components[i][j].neighborhood().nodes().difference(eles);
         positioned.push(false);
-        if(neighbors.length > 1 && !isPositioned){
+        if (neighbors.length > 1 && !isPositioned) {
           multNeig = true;
           positioned[j] = true;
           multneighbors = neighbors;
@@ -65,7 +65,7 @@ var layoutUtilities = function (cy, options) {
           y = components[i][j].position("y");
           isPositioned = true;
         }
-        else if(neighbors.length == 1 && !isPositioned){
+        else if (neighbors.length == 1 && !isPositioned) {
           oneNeig = true;
           mainEle = neighbors[0];
           positioned[j] = true;
@@ -75,28 +75,28 @@ var layoutUtilities = function (cy, options) {
           isPositioned = true;
         }
       }
-      
-      if(oneNeig || multNeig){
-        for(var j=0; j<components[i].length; j++){
-          if(positioned[j] == false){
+
+      if (oneNeig || multNeig) {
+        for (var j = 0; j < components[i].length; j++) {
+          if (positioned[j] == false) {
             var neighbors = components[i][j].neighborhood().nodes();
             var positionedNeigbors = [];
             var curr = components[i][j].neighborhood().nodes().difference(eles);
-            curr.forEach(function(ele){
+            curr.forEach(function (ele) {
               positionedNeigbors.push(ele);
             })
-           
-            for(var k =0; k< neighbors.length; k++){
-              if(positioned[components[i].indexOf(neighbors[k])]){
+
+            for (var k = 0; k < neighbors.length; k++) {
+              if (positioned[components[i].indexOf(neighbors[k])]) {
                 positionedNeigbors.push(neighbors[k]);
               }
             }
             if (positionedNeigbors.length > 1) {
               instance.nodeWithMultipleNeighbors(components[i][j], positionedNeigbors);
-            } else if(positionedNeigbors.length == 1) instance.nodeWithOneNeighbor(positionedNeigbors[0], components[i][j]);
-            else{
-              var horizontalP = instance.generateRandom(options.offset, options.offset *2 , 0);
-              var verticalP = instance.generateRandom(options.offset, options.offset *2, 0);
+            } else if (positionedNeigbors.length == 1) instance.nodeWithOneNeighbor(positionedNeigbors[0], components[i][j]);
+            else {
+              var horizontalP = instance.generateRandom(options.offset, options.offset * 2, 0);
+              var verticalP = instance.generateRandom(options.offset, options.offset * 2, 0);
               components[i][j].position("x", x + horizontalP);
               components[i][j].position("y", y + verticalP);
             }
@@ -104,25 +104,25 @@ var layoutUtilities = function (cy, options) {
           }
         }
       }
-      else{
+      else {
         disconnectedComp.push(components[i]);
       }
     }
 
-    if(disconnectedComp.length >= 1){
+    if (disconnectedComp.length >= 1) {
       instance.disconnectedNodes(disconnectedComp);
     }
   };
 
-  instance.disconnectedNodes = function (components){
+  instance.disconnectedNodes = function (components) {
     var leftX = Number.MAX_VALUE;
     var rightX = Number.MIN_VALUE;
     var topY = Number.MAX_VALUE;
     var bottomY = Number.MIN_VALUE;
     // Check the x and y limits of all hidden elements and store them in the variables above
-    cy.nodes(':visible').forEach(function(node){
-      var halfWidth = node.outerWidth()/2;
-      var halfHeight = node.outerHeight()/2;
+    cy.nodes(':visible').forEach(function (node) {
+      var halfWidth = node.outerWidth() / 2;
+      var halfHeight = node.outerHeight() / 2;
       if (node.position("x") - halfWidth < leftX)
         leftX = node.position("x") - halfWidth;
       if (node.position("x") + halfWidth > rightX)
@@ -132,55 +132,55 @@ var layoutUtilities = function (cy, options) {
       if (node.position("y") + halfHeight > bottomY)
         bottomY = node.position("y") + halfHeight;
     });
- 
+
     var radiusy = topY - bottomY;
     var radiusx = rightX - leftX;
     var innerRadius = (Math.sqrt(radiusx * radiusx + radiusy * radiusy)) / 2;
-    var centerX = (leftX + rightX)/2;
-    var centerY = (topY + bottomY)/2;
+    var centerX = (leftX + rightX) / 2;
+    var centerY = (topY + bottomY) / 2;
     //var components = this.findComponents(newEles);
     var numOfComponents = components.length;
-    var angle = 360/numOfComponents;
+    var angle = 360 / numOfComponents;
     var count = 1;
 
-    components.forEach(function(component){
+    components.forEach(function (component) {
 
       var distFromCenter = instance.generateRandom(innerRadius + options.offset * 6, innerRadius + options.offset * 8, 1);
       var curAngle = angle * count;
-      var angleInRadians = curAngle * Math.PI /180;
+      var angleInRadians = curAngle * Math.PI / 180;
       var x = centerX + distFromCenter * Math.cos(angleInRadians);
       var y = centerY + distFromCenter * Math.sin(angleInRadians);
 
-      if(component.length == 1){
+      if (component.length == 1) {
         component[0].position("x", x);
         component[0].position("y", y);
       }
-      else{
+      else {
         var max = 0;
         var index = 0;
         var positioned = [];
-        for(var i=0; i<component.length; i++){
+        for (var i = 0; i < component.length; i++) {
           positioned.push(false);
         }
 
         positioned[0] = true;
         component[0].position("x", x);
         component[0].position("y", y);
-          
-        for(var i=1; i<component.length; i++){
+
+        for (var i = 1; i < component.length; i++) {
           var neighbors = component[i].neighborhood().nodes();
           var positionedNeigbors = [];
-          for(var j =0; j< neighbors.length; j++){
-            if(positioned[component.indexOf(neighbors[j])]){
+          for (var j = 0; j < neighbors.length; j++) {
+            if (positioned[component.indexOf(neighbors[j])]) {
               positionedNeigbors.push(neighbors[j]);
             }
           }
           if (positionedNeigbors.length > 1) {
             instance.nodeWithMultipleNeighbors(component[i], positionedNeigbors);
-          } else if(positionedNeigbors.length == 1) instance.nodeWithOneNeighbor(positionedNeigbors[0], component[i]);
-          else{
-            var horizontalP = instance.generateRandom(options.offset, options.offset *2 , 0);
-            var verticalP = instance.generateRandom(options.offset, options.offset *2, 0);
+          } else if (positionedNeigbors.length == 1) instance.nodeWithOneNeighbor(positionedNeigbors[0], component[i]);
+          else {
+            var horizontalP = instance.generateRandom(options.offset, options.offset * 2, 0);
+            var verticalP = instance.generateRandom(options.offset, options.offset * 2, 0);
             component[i].position("x", x + horizontalP);
             component[i].position("y", y + verticalP);
           }
@@ -191,415 +191,404 @@ var layoutUtilities = function (cy, options) {
     });
   };
 
-  instance.findComponents = function(newEles){
-    
+  instance.findComponents = function (newEles) {
+
     var adjListArray = [];
     var current = cy.nodes().difference(newEles);
-    newEles.forEach(function(ele){
+    newEles.forEach(function (ele) {
       var neighbors = ele.neighborhood().nodes().difference(current);
       var listOfIndexes = [];
-      neighbors.forEach(function(neigbor){
-          var index = newEles.indexOf(neigbor);
-          listOfIndexes.push(index);
+      neighbors.forEach(function (neigbor) {
+        var index = newEles.indexOf(neigbor);
+        listOfIndexes.push(index);
       });
       adjListArray.push(listOfIndexes);
     });
 
     // Mark all the vertices as not visited 
-    var visited = []; 
-    for(var v = 0; v < newEles.length; v++){
-        visited.push(false); 
+    var visited = [];
+    for (var v = 0; v < newEles.length; v++) {
+      visited.push(false);
     }
 
     var listOfComponents = [];
-    
-  
-    for (var v=0; v<newEles.length; v++) 
-    { 
-        var elesOfComponent = [];
-        if (visited[v] == false) 
-        { 
-            // print all reachable vertices 
-            // from v 
-            this.DFSUtil(v, visited, adjListArray, newEles, elesOfComponent); 
-            listOfComponents.push(elesOfComponent);
-        } 
+
+
+    for (var v = 0; v < newEles.length; v++) {
+      var elesOfComponent = [];
+      if (visited[v] == false) {
+        // print all reachable vertices 
+        // from v 
+        this.DFSUtil(v, visited, adjListArray, newEles, elesOfComponent);
+        listOfComponents.push(elesOfComponent);
+      }
     }
-    
+
     return listOfComponents;
   };
 
-  instance.DFSUtil = function(v, visited, adjListArray, newEles, elesOfComponent){
+  instance.DFSUtil = function (v, visited, adjListArray, newEles, elesOfComponent) {
     // Mark the current node as visited and print it 
-    visited[v] = true; 
+    visited[v] = true;
     elesOfComponent.push(newEles[v]);
     // Recur for all the vertices 
     // adjacent to this vertex 
-    for (var i=0; i<adjListArray[v].length ; i++) { 
-      if(!visited[adjListArray[v][i]]) this.DFSUtil(adjListArray[v][i], visited, adjListArray, newEles, elesOfComponent); 
-    } 
-  }; 
+    for (var i = 0; i < adjListArray[v].length; i++) {
+      if (!visited[adjListArray[v][i]]) this.DFSUtil(adjListArray[v][i], visited, adjListArray, newEles, elesOfComponent);
+    }
+  };
 
-  instance.nodeWithOneNeighbor = function(mainEle, hiddenEle) {
+  instance.nodeWithOneNeighbor = function (mainEle, hiddenEle) {
     var quadrants = instance.checkOccupiedQuadrants(mainEle, hiddenEle);
     var freeQuadrants = [];
     for (var property in quadrants) {
-        if (quadrants[property] === "free")
-            freeQuadrants.push(property);
+      if (quadrants[property] === "free")
+        freeQuadrants.push(property);
     }
     //Can take values 1 and -1 and are used to place the hidden nodes in the random quadrant
     var horizontalMult;
     var verticalMult;
-    if (freeQuadrants.length > 0)
-    {
-      if (freeQuadrants.length === 3)
-      {
-        if (freeQuadrants.includes('first') && freeQuadrants.includes('second') && freeQuadrants.includes('third'))
-        {
+    if (freeQuadrants.length > 0) {
+      if (freeQuadrants.length === 3) {
+        if (freeQuadrants.includes('first') && freeQuadrants.includes('second') && freeQuadrants.includes('third')) {
           horizontalMult = -1;
           verticalMult = -1;
         }
-        else if (freeQuadrants.includes('first') && freeQuadrants.includes('second') && freeQuadrants.includes('fourth'))
-        {
+        else if (freeQuadrants.includes('first') && freeQuadrants.includes('second') && freeQuadrants.includes('fourth')) {
           horizontalMult = 1;
           verticalMult = -1;
         }
-        else if (freeQuadrants.includes('first') && freeQuadrants.includes('third') && freeQuadrants.includes('fourth'))
-        {
+        else if (freeQuadrants.includes('first') && freeQuadrants.includes('third') && freeQuadrants.includes('fourth')) {
           horizontalMult = 1;
           verticalMult = 1;
         }
-        else if (freeQuadrants.includes('second') && freeQuadrants.includes('third') && freeQuadrants.includes('fourth'))
-        {
+        else if (freeQuadrants.includes('second') && freeQuadrants.includes('third') && freeQuadrants.includes('fourth')) {
           horizontalMult = -1;
           verticalMult = 1;
         }
       }
-      else
-      {
+      else {
         //Randomly picks one quadrant from the free quadrants
-        var randomQuadrant = freeQuadrants[Math.floor(Math.random()*freeQuadrants.length)];
+        var randomQuadrant = freeQuadrants[Math.floor(Math.random() * freeQuadrants.length)];
 
         if (randomQuadrant === "first") {
-            horizontalMult = 1;
-            verticalMult = -1;
+          horizontalMult = 1;
+          verticalMult = -1;
         }
         else if (randomQuadrant === "second") {
-            horizontalMult = -1;
-            verticalMult = -1;
+          horizontalMult = -1;
+          verticalMult = -1;
         }
         else if (randomQuadrant === "third") {
-            horizontalMult = -1;
-            verticalMult = 1;
+          horizontalMult = -1;
+          verticalMult = 1;
         }
         else if (randomQuadrant === "fourth") {
-            horizontalMult = 1;
-            verticalMult = 1;
+          horizontalMult = 1;
+          verticalMult = 1;
         }
       }
     }
-    else
-    {
-        horizontalMult = 0;
-        verticalMult = 0;
+    else {
+      horizontalMult = 0;
+      verticalMult = 0;
     }
     //Change the position of hidden elements
-  
+
     var horizontalParam = instance.generateRandom(options.idealEdgeLength - options.offset, options.idealEdgeLength + options.offset, horizontalMult);
     var verticalParam = instance.generateRandom(options.idealEdgeLength - options.offset, options.idealEdgeLength + options.offset, verticalMult);
     var newCenterX = mainEle.position("x") + horizontalParam;
     var newCenterY = mainEle.position("y") + verticalParam;
     hiddenEle.position("x", newCenterX);
-    hiddenEle.position("y",newCenterY);
+    hiddenEle.position("y", newCenterY);
   };
 
-  instance.nodeWithMultipleNeighbors = function(ele, neighbors){
-    if(neighbors == null){
+  instance.nodeWithMultipleNeighbors = function (ele, neighbors) {
+    if (neighbors == null) {
       var neighbors = ele.neighborhood().nodes(":visible");
     }
-      var x = 0;
-      var y = 0;
-      var count = 0;
-      neighbors.forEach(function(ele1){
-        x += ele1.position("x");
-        y += ele1.position("y");
-        count ++;
-      });
-      x = x / count;
-      y = y / count ;
-      var diffx = instance.generateRandom(0, options.offset/2, 0);
-      var diffy = instance.generateRandom(0, options.offset/2, 0);
-      ele.position("x", x + diffx);
-      ele.position("y", y + diffy);
+    var x = 0;
+    var y = 0;
+    var count = 0;
+    neighbors.forEach(function (ele1) {
+      x += ele1.position("x");
+      y += ele1.position("y");
+      count++;
+    });
+    x = x / count;
+    y = y / count;
+    var diffx = instance.generateRandom(0, options.offset / 2, 0);
+    var diffy = instance.generateRandom(0, options.offset / 2, 0);
+    ele.position("x", x + diffx);
+    ele.position("y", y + diffy);
   }
 
-  instance.generateRandom = function(min, max, mult) {
-    var val = [-1,1];
+  instance.generateRandom = function (min, max, mult) {
+    var val = [-1, 1];
     if (mult === 0)
-        mult = val[Math.floor(Math.random()*val.length)];
+      mult = val[Math.floor(Math.random() * val.length)];
     return (Math.floor(Math.random() * (max - min + 1)) + min) * mult;
   };
 
-  instance.checkOccupiedQuadrants = function(mainEle, hiddenEles) {
+  instance.checkOccupiedQuadrants = function (mainEle, hiddenEles) {
     var visibleEles = mainEle.neighborhood().difference(hiddenEles).nodes();
-    var occupiedQuadrants = {first:"free", second:"free", third:"free", fourth:"free"};
+    var occupiedQuadrants = { first: "free", second: "free", third: "free", fourth: "free" };
 
-    visibleEles.forEach(function( ele ){
-        if (ele.data('class') != 'compartment' &&  ele.data('class') != 'complex')
-        {
-            if (ele.position("x") < mainEle.position("x") && ele.position("y") < mainEle.position("y"))
-                occupiedQuadrants.second = "occupied";
-            else if (ele.position("x") > mainEle.position("x") && ele.position("y") < mainEle.position("y"))
-                occupiedQuadrants.first = "occupied";
-            else if (ele.position("x") < mainEle.position("x") && ele.position("y") > mainEle.position("y"))
-                occupiedQuadrants.third = "occupied";
-            else if (ele.position("x") > mainEle.position("x") && ele.position("y") > mainEle.position("y"))
-                occupiedQuadrants.fourth = "occupied";
-        }
+    visibleEles.forEach(function (ele) {
+      if (ele.data('class') != 'compartment' && ele.data('class') != 'complex') {
+        if (ele.position("x") < mainEle.position("x") && ele.position("y") < mainEle.position("y"))
+          occupiedQuadrants.second = "occupied";
+        else if (ele.position("x") > mainEle.position("x") && ele.position("y") < mainEle.position("y"))
+          occupiedQuadrants.first = "occupied";
+        else if (ele.position("x") < mainEle.position("x") && ele.position("y") > mainEle.position("y"))
+          occupiedQuadrants.third = "occupied";
+        else if (ele.position("x") > mainEle.position("x") && ele.position("y") > mainEle.position("y"))
+          occupiedQuadrants.fourth = "occupied";
+      }
     });
     return occupiedQuadrants;
   };
 
- 
-  instance.packComponents = function(components){
+
+  instance.packComponents = function (components) {
     let currentCenter = generalUtils.getCenter(components);
 
     var gridStep = 0;
     var totalNodes = 0;
-    components.forEach(function(component){
+    components.forEach(function (component) {
       totalNodes += component.nodes.length;
-      component.nodes.forEach(function(node){
+      component.nodes.forEach(function (node) {
         gridStep += node.width + node.height;
-      }); 
-    });   
+      });
+    });
 
     gridStep = gridStep / (2 * totalNodes);
     gridStep = Math.floor(gridStep * options.polyominoGridSizeFactor);
 
-    if(options.componentSpacing > 0){
+    if (options.componentSpacing > 0) {
       var spacingAmount = options.componentSpacing;
-      components.forEach(function(component){        
-        component.nodes.forEach(function(node){
+      components.forEach(function (component) {
+        component.nodes.forEach(function (node) {
           node.x = node.x - spacingAmount;
           node.y = node.y - spacingAmount;
-          node.width = node.width + (2* spacingAmount);
-          node.height = node.height + (2*spacingAmount);
-        }); 
-      });   
+          node.width = node.width + (2 * spacingAmount);
+          node.height = node.height + (2 * spacingAmount);
+        });
+      });
     }
     var gridWidth = 0, gridHeight = 0;
     var polyominos = [];
-    var globalX1 = 10000, globalX2=0,globalY1= 10000,globalY2=0 ;
+    var globalX1 = 10000, globalX2 = 0, globalY1 = 10000, globalY2 = 0;
     //create polyominos for components
-    components.forEach(function(component,index){
-      var x1 = 10000, x2= 0,y1 = 10000,y2=0;
-      component.nodes.forEach(function(node){
-        if(node.x <= x1) x1 = node.x;
-        if(node.y <= y1) y1 = node.y;
-        if(node.x + node.width >= x2) x2 = node.x + node.width;
-        if(node.y + node.height >= y2) y2 = node.y + node.height;         
-      }); 
+    components.forEach(function (component, index) {
+      var x1 = 10000, x2 = 0, y1 = 10000, y2 = 0;
+      component.nodes.forEach(function (node) {
+        if (node.x <= x1) x1 = node.x;
+        if (node.y <= y1) y1 = node.y;
+        if (node.x + node.width >= x2) x2 = node.x + node.width;
+        if (node.y + node.height >= y2) y2 = node.y + node.height;
+      });
 
-      component.edges.forEach(function(edge){
-        if(edge.startX<= x1) x1 = edge.startX;
-        if(edge.startY <= y1) y1 = edge.startY;
-        if(edge.endX >= x2) x2 = edge.endX;
-        if(edge.endY >= y2) y2 = edge.endY;         
-      }); 
+      component.edges.forEach(function (edge) {
+        if (edge.startX <= x1) x1 = edge.startX;
+        if (edge.startY <= y1) y1 = edge.startY;
+        if (edge.endX >= x2) x2 = edge.endX;
+        if (edge.endY >= y2) y2 = edge.endY;
+      });
 
-      if(x1<globalX1) globalX1 = x1;
-      if(x2>globalX2) globalX2 = x2;
-      if(y1<globalY1) globalY1 = y1;
-      if(y2>globalY2) globalY2 = y2;    
+      if (x1 < globalX1) globalX1 = x1;
+      if (x2 > globalX2) globalX2 = x2;
+      if (y1 < globalY1) globalY1 = y1;
+      if (y2 > globalY2) globalY2 = y2;
 
-      gridWidth += (x2-x1);
-      gridHeight += (y2-y1);
-      var componentWidth = Math.floor((x2-x1)/ gridStep) + 1;
-      var componentHeight = Math.floor((y2-y1)/ gridStep) + 1;
+      gridWidth += (x2 - x1);
+      gridHeight += (y2 - y1);
+      var componentWidth = Math.floor((x2 - x1) / gridStep) + 1;
+      var componentHeight = Math.floor((y2 - y1) / gridStep) + 1;
 
-      var componentPolyomino = new polyominoPacking.Polyomino(componentWidth,componentHeight,index,x1,y1);
+      var componentPolyomino = new polyominoPacking.Polyomino(componentWidth, componentHeight, index, x1, y1);
 
       //fill nodes to polyomino cells
-      component.nodes.forEach(function(node){
+      component.nodes.forEach(function (node) {
         //top left cell of a node
-       var topLeftX = Math.floor((node.x - x1 ) / gridStep);
-       var topLeftY = Math.floor((node.y - y1) / gridStep);     
+        var topLeftX = Math.floor((node.x - x1) / gridStep);
+        var topLeftY = Math.floor((node.y - y1) / gridStep);
 
-       //bottom right cell of a node
-       var bottomRightX = Math.floor((node.x + node.width - x1)/ gridStep);
-       var bottomRightY = Math.floor((node.y+ node.height - y1)/ gridStep);
+        //bottom right cell of a node
+        var bottomRightX = Math.floor((node.x + node.width - x1) / gridStep);
+        var bottomRightY = Math.floor((node.y + node.height - y1) / gridStep);
 
-       //all cells between topleft cell and bottom right cell should be occupied
-       for(var i = topLeftX ; i <= bottomRightX ; i++){
-         for(var j = topLeftY; j <= bottomRightY ; j++){
-           componentPolyomino.grid[i][j] = true;
-           
-         }
-       }
-      }); 
+        //all cells between topleft cell and bottom right cell should be occupied
+        for (var i = topLeftX; i <= bottomRightX; i++) {
+          for (var j = topLeftY; j <= bottomRightY; j++) {
+            componentPolyomino.grid[i][j] = true;
+
+          }
+        }
+      });
 
       //fill cells where edges pass 
-      component.edges.forEach(function(edge){
-         var p0 = {} , p1 = {};
-         p0.x = (edge.startX - x1 ) / gridStep;
-         p0.y = (edge.startY - y1) / gridStep;
-         p1.x = (edge.endX - x1) / gridStep;
-         p1.y = (edge.endY - y1) / gridStep;
-         //for every edge calculate the super cover 
-        var points = generalUtils.LineSuperCover(p0,p1)        
-        points.forEach(function(point){          
+      component.edges.forEach(function (edge) {
+        var p0 = {}, p1 = {};
+        p0.x = (edge.startX - x1) / gridStep;
+        p0.y = (edge.startY - y1) / gridStep;
+        p1.x = (edge.endX - x1) / gridStep;
+        p1.y = (edge.endY - y1) / gridStep;
+        //for every edge calculate the super cover 
+        var points = generalUtils.LineSuperCover(p0, p1)
+        points.forEach(function (point) {
           var indexX = Math.floor(point.x);
           var indexY = Math.floor(point.y)
-          if(indexX >= 0 && indexX < componentPolyomino.width && indexY >=0 && indexY < componentPolyomino.height){
+          if (indexX >= 0 && indexX < componentPolyomino.width && indexY >= 0 && indexY < componentPolyomino.height) {
             componentPolyomino.grid[Math.floor(point.x)][Math.floor(point.y)] = true;
           }
         });
       });
 
       //update number of occupied cells in polyomino
-      for(var i = 0 ; i <componentPolyomino.width ; i++){
-        for(var j = 0; j < componentPolyomino.height ; j++){
-          if(componentPolyomino.grid[i][j]) componentPolyomino.numberOfOccupiredCells++;
-          
+      for (var i = 0; i < componentPolyomino.width; i++) {
+        for (var j = 0; j < componentPolyomino.height; j++) {
+          if (componentPolyomino.grid[i][j]) componentPolyomino.numberOfOccupiredCells++;
+
         }
-      }      
-      polyominos.push(componentPolyomino);       
+      }
+      polyominos.push(componentPolyomino);
     });
 
-    var componentsCenter = new polyominoPacking.Point((globalX1+globalX2)/2, (globalY1+globalY2)/2);
-    var componentsCenteronGrid = new polyominoPacking.Point(Math.floor(componentsCenter.x/gridStep), Math.floor(componentsCenter.y/gridStep));
+    var componentsCenter = new polyominoPacking.Point((globalX1 + globalX2) / 2, (globalY1 + globalY2) / 2);
+    var componentsCenteronGrid = new polyominoPacking.Point(Math.floor(componentsCenter.x / gridStep), Math.floor(componentsCenter.y / gridStep));
     //order plyominos non-increasing order
-    polyominos.sort(function(a,b){
-        var aSize = a.width*a.height;
-        var bSize = b.width*b.height;
-        // a should come before b in the sorted order
-        if(aSize > bSize){
-          return -1;
+    polyominos.sort(function (a, b) {
+      var aSize = a.width * a.height;
+      var bSize = b.width * b.height;
+      // a should come before b in the sorted order
+      if (aSize > bSize) {
+        return -1;
         // a should come after b in the sorted order
-        }else if(aSize < bSize){
-          return 1;
+      } else if (aSize < bSize) {
+        return 1;
         // a and b are the same
-        }else{
-          return 0;
-        }
-    });  
+      } else {
+        return 0;
+      }
+    });
 
     //main grid width and height is two the times the sum of all components widths and heights (worst case scenario)
-    gridWidth = Math.ceil(gridWidth*2/gridStep);
-    gridHeight = Math.ceil(gridHeight*2/gridStep);
-    
+    gridWidth = Math.ceil(gridWidth * 2 / gridStep);
+    gridHeight = Math.ceil(gridHeight * 2 / gridStep);
+
     //intialize the grid add 1 to avoid insufficient grid space due to divisin by 2 in calcuations
-    var mainGrid = new polyominoPacking.Grid(gridWidth + 1 ,gridHeight + 1);
+    var mainGrid = new polyominoPacking.Grid(gridWidth + 1, gridHeight + 1);
 
     //place first (biggest) polyomino in the center
-    mainGrid.placePolyomino(polyominos[0], mainGrid.center.x,mainGrid.center.y);
-    
+    mainGrid.placePolyomino(polyominos[0], mainGrid.center.x, mainGrid.center.y);
 
-   
+
+
     //for every polyomino try placeing it in first neighbors and calculate utility if none then second neighbor and so on..
-    for(var i = 1 ; i< polyominos.length;i++){
+    for (var i = 1; i < polyominos.length; i++) {
       var fullnessMax = 0;
-      var adjustedFullnessMax = 0;      
+      var adjustedFullnessMax = 0;
       var weigthFullnessAspectRatio = 0;
       var minAspectRatioDiff = 1000000;
       var placementFound = false;
       var cells = [];
       var resultLocation = {};
-      while(!placementFound){
+      while (!placementFound) {
 
-        cells = mainGrid.getDirectNeighbors(cells, Math.ceil(Math.max(polyominos[i].width,polyominos[i].height) / 2));
-        cells.forEach(function(cell){
-            if(mainGrid.tryPlacingPolyomino(polyominos[i], cell.x, cell.y)){
-              placementFound = true;
-              var utilityValue = mainGrid.calculateUtilityOfPlacing(polyominos[i],cell.x,cell.y, options.desiredAspectRatio); 
-              var cellChosen = false;
-              if(options.utilityFunction == 1){
-                if( utilityValue.adjustedFullness   > adjustedFullnessMax){
-                  cellChosen = true;                
-                }else if(utilityValue.adjustedFullness == adjustedFullnessMax){
-                  if(utilityValue.fullness > fullnessMax){
+        cells = mainGrid.getDirectNeighbors(cells, Math.ceil(Math.max(polyominos[i].width, polyominos[i].height) / 2));
+        cells.forEach(function (cell) {
+          if (mainGrid.tryPlacingPolyomino(polyominos[i], cell.x, cell.y)) {
+            placementFound = true;
+            var utilityValue = mainGrid.calculateUtilityOfPlacing(polyominos[i], cell.x, cell.y, options.desiredAspectRatio);
+            var cellChosen = false;
+            if (options.utilityFunction == 1) {
+              if (utilityValue.adjustedFullness > adjustedFullnessMax) {
+                cellChosen = true;
+              } else if (utilityValue.adjustedFullness == adjustedFullnessMax) {
+                if (utilityValue.fullness > fullnessMax) {
+                  cellChosen = true;
+
+                } else if (utilityValue.fullness == fullnessMax) {
+                  if (Math.abs(utilityValue.actualAspectRatio - options.desiredAspectRatio) <= minAspectRatioDiff) {
                     cellChosen = true;
-                   
-                  }else if( utilityValue.fullness == fullnessMax){
-                    if(Math.abs(utilityValue.actualAspectRatio - options.desiredAspectRatio) <= minAspectRatioDiff){
-                      cellChosen = true;                      
-                    }
-                  }                 
+                  }
                 }
-                if(cellChosen){
-                  adjustedFullnessMax= utilityValue.adjustedFullness;
-                  minAspectRatioDiff = Math.abs(utilityValue.actualAspectRatio - options.desiredAspectRatio);
-                  fullnessMax = utilityValue.fullness;
-                  resultLocation.x = cell.x;
-                  resultLocation.y = cell.y;
-                }
-
-              }else  if(options.utilityFunction == 2){
-                var aspectRatioDiff = Math.abs(utilityValue.actualAspectRatio - options.desiredAspectRatio);
-                var weightedUtility = (utilityValue.fullness * .5) + ((1- aspectRatioDiff/Math.max(utilityValue.actualAspectRatio,options.desiredAspectRatio) * .5))
-                if(weightedUtility > weigthFullnessAspectRatio){
-                  weigthFullnessAspectRatio = weightedUtility;
-                  resultLocation.x = cell.x;
-                  resultLocation.y = cell.y;
-                }
-               
               }
-              
+              if (cellChosen) {
+                adjustedFullnessMax = utilityValue.adjustedFullness;
+                minAspectRatioDiff = Math.abs(utilityValue.actualAspectRatio - options.desiredAspectRatio);
+                fullnessMax = utilityValue.fullness;
+                resultLocation.x = cell.x;
+                resultLocation.y = cell.y;
+              }
+
+            } else if (options.utilityFunction == 2) {
+              var aspectRatioDiff = Math.abs(utilityValue.actualAspectRatio - options.desiredAspectRatio);
+              var weightedUtility = (utilityValue.fullness * .5) + ((1 - aspectRatioDiff / Math.max(utilityValue.actualAspectRatio, options.desiredAspectRatio) * .5))
+              if (weightedUtility > weigthFullnessAspectRatio) {
+                weigthFullnessAspectRatio = weightedUtility;
+                resultLocation.x = cell.x;
+                resultLocation.y = cell.y;
+              }
+
             }
+
+          }
         });
-      }    
-     
-      mainGrid.placePolyomino(polyominos[i],resultLocation.x,resultLocation.y);
-    }  
+      }
+
+      mainGrid.placePolyomino(polyominos[i], resultLocation.x, resultLocation.y);
+    }
 
     //sort polyominos according to index of input to return correct output order
-    polyominos.sort(function(a,b){
-      if(a.index < b.index){
+    polyominos.sort(function (a, b) {
+      if (a.index < b.index) {
         return -1;
-      }else if(a.index > b.index){
+      } else if (a.index > b.index) {
         return 1;
-      }else{
+      } else {
         return 0;
       }
-  });  
-    
-  var packingResult = {};
-  packingResult.shifts = []
-  
- /*  var shiftX = componentsCenter.x - ((mainGrid.center.x - mainGrid.occupiedRectangle.x1)*gridStep); 
-  var shiftY = componentsCenter.y - ((mainGrid.center.y - mainGrid.occupiedRectangle.y1)*gridStep); 
-  var occupiedCenterX = Math.floor((mainGrid.occupiedRectangle.x1 + mainGrid.occupiedRectangle.x2)/2);
-  var occupiedCenterY = Math.floor((mainGrid.occupiedRectangle.y1 + mainGrid.occupiedRectangle.y2)/2); */
+    });
+
+    var packingResult = {};
+    packingResult.shifts = []
+
+    /*  var shiftX = componentsCenter.x - ((mainGrid.center.x - mainGrid.occupiedRectangle.x1)*gridStep); 
+     var shiftY = componentsCenter.y - ((mainGrid.center.y - mainGrid.occupiedRectangle.y1)*gridStep); 
+     var occupiedCenterX = Math.floor((mainGrid.occupiedRectangle.x1 + mainGrid.occupiedRectangle.x2)/2);
+     var occupiedCenterY = Math.floor((mainGrid.occupiedRectangle.y1 + mainGrid.occupiedRectangle.y2)/2); */
     let rectCenter = mainGrid.occupiedRectangle.center();
 
     let renderedCenter = new Point(rectCenter.x * gridStep, rectCenter.y * gridStep);
-    
+
     let centerShift = renderedCenter.diff(currentCenter);
 
-    polyominos.forEach(function(pol){
+    polyominos.forEach(function (pol) {
       var dx = (pol.location.x - pol.center.x - mainGrid.occupiedRectangle.x1) * gridStep - pol.leftMostCoord + centerShift.x;//+shiftX;
-      var dy = (pol.location.y -pol.center.y - mainGrid.occupiedRectangle.y1) * gridStep - pol.topMostCoord + centerShift.y;// + shiftY;
+      var dy = (pol.location.y - pol.center.y - mainGrid.occupiedRectangle.y1) * gridStep - pol.topMostCoord + centerShift.y;// + shiftY;
       //var dx = (pol.location.x -occupiedCenterX) * gridStep + componentsCenter.x- pol.leftMostCoord;//+shiftX;
       //var dy = (pol.location.y -occupiedCenterY) * gridStep + componentsCenter.y-pol.topMostCoord;// + shiftY;
-      packingResult.shifts.push({dx: dx, dy: dy});
+      packingResult.shifts.push({ dx: dx, dy: dy });
     });
 
-    packingResult.aspectRatio = Math.round( ((mainGrid.occupiedRectangle.x2 - mainGrid.occupiedRectangle.x1 + 1)/(mainGrid.occupiedRectangle.y2 - mainGrid.occupiedRectangle.y1 + 1)) * 1e2 ) / 1e2;
-    packingResult.fullness = Math.round( ((mainGrid.numberOfOccupiredCells / ((mainGrid.occupiedRectangle.x2 - mainGrid.occupiedRectangle.x1 + 1)*(mainGrid.occupiedRectangle.y2 - mainGrid.occupiedRectangle.y1 + 1)))*100) * 1e2 ) / 1e2;
-    
-    if(packingResult.aspectRatio > options.desiredAspectRatio){
+    packingResult.aspectRatio = Math.round(((mainGrid.occupiedRectangle.x2 - mainGrid.occupiedRectangle.x1 + 1) / (mainGrid.occupiedRectangle.y2 - mainGrid.occupiedRectangle.y1 + 1)) * 1e2) / 1e2;
+    packingResult.fullness = Math.round(((mainGrid.numberOfOccupiredCells / ((mainGrid.occupiedRectangle.x2 - mainGrid.occupiedRectangle.x1 + 1) * (mainGrid.occupiedRectangle.y2 - mainGrid.occupiedRectangle.y1 + 1))) * 100) * 1e2) / 1e2;
+
+    if (packingResult.aspectRatio > options.desiredAspectRatio) {
       var mainGridWidth = mainGrid.occupiedRectangle.x2 - mainGrid.occupiedRectangle.x1 + 1;
-      packingResult.adjustedFullness = Math.round( (((mainGrid.numberOfOccupiredCells) / (mainGridWidth* (mainGridWidth/options.desiredAspectRatio))*100)) * 1e2 ) / 1e2;
-     // height = width / desiredAspectRatio;
-  }else{
+      packingResult.adjustedFullness = Math.round((((mainGrid.numberOfOccupiredCells) / (mainGridWidth * (mainGridWidth / options.desiredAspectRatio)) * 100)) * 1e2) / 1e2;
+      // height = width / desiredAspectRatio;
+    } else {
 
-    var mainGridheight = mainGrid.occupiedRectangle.y2 - mainGrid.occupiedRectangle.y1 + 1;
-    packingResult.adjustedFullness = Math.round( (((mainGrid.numberOfOccupiredCells) / ((mainGridheight* options.desiredAspectRatio)* mainGridheight))*100) * 1e2 ) / 1e2;
+      var mainGridheight = mainGrid.occupiedRectangle.y2 - mainGrid.occupiedRectangle.y1 + 1;
+      packingResult.adjustedFullness = Math.round((((mainGrid.numberOfOccupiredCells) / ((mainGridheight * options.desiredAspectRatio) * mainGridheight)) * 100) * 1e2) / 1e2;
 
-     // width = height * desiredAspectRatio;
-  }
-     
-   
+      // width = height * desiredAspectRatio;
+    }
+
+
     return packingResult;
   }
 

--- a/src/core/layout-utilities.js
+++ b/src/core/layout-utilities.js
@@ -156,8 +156,6 @@ var layoutUtilities = function (cy, options) {
         component[0].position("y", y);
       }
       else {
-        var max = 0;
-        var index = 0;
         var positioned = [];
         for (var i = 0; i < component.length; i++) {
           positioned.push(false);
@@ -321,7 +319,7 @@ var layoutUtilities = function (cy, options) {
     var diffy = instance.generateRandom(0, options.offset / 2, 0);
     ele.position("x", x + diffx);
     ele.position("y", y + diffy);
-  }
+  };
 
   instance.generateRandom = function (min, max, mult) {
     var val = [-1, 1];
@@ -434,10 +432,10 @@ var layoutUtilities = function (cy, options) {
         p1.x = (edge.endX - x1) / gridStep;
         p1.y = (edge.endY - y1) / gridStep;
         //for every edge calculate the super cover 
-        var points = generalUtils.LineSuperCover(p0, p1)
+        var points = generalUtils.LineSuperCover(p0, p1);
         points.forEach(function (point) {
           var indexX = Math.floor(point.x);
-          var indexY = Math.floor(point.y)
+          var indexY = Math.floor(point.y);
           if (indexX >= 0 && indexX < componentPolyomino.width && indexY >= 0 && indexY < componentPolyomino.height) {
             componentPolyomino.grid[Math.floor(point.x)][Math.floor(point.y)] = true;
           }
@@ -454,9 +452,6 @@ var layoutUtilities = function (cy, options) {
       polyominos.push(componentPolyomino);
     });
 
-    // These variables are not used anywhere. Should be safe to remove
-    var componentsCenter = new polyominoPacking.Point((globalX1 + globalX2) / 2, (globalY1 + globalY2) / 2);
-    var componentsCenteronGrid = new polyominoPacking.Point(Math.floor(componentsCenter.x / gridStep), Math.floor(componentsCenter.y / gridStep));
     //order plyominos non-increasing order
     polyominos.sort(function (a, b) {
       var aSize = a.width * a.height;
@@ -523,15 +518,13 @@ var layoutUtilities = function (cy, options) {
 
             } else if (options.utilityFunction == 2) {
               var aspectRatioDiff = Math.abs(utilityValue.actualAspectRatio - options.desiredAspectRatio);
-              var weightedUtility = (utilityValue.fullness * .5) + ((1 - aspectRatioDiff / Math.max(utilityValue.actualAspectRatio, options.desiredAspectRatio) * .5))
+              var weightedUtility = (utilityValue.fullness * .5) + ((1 - aspectRatioDiff / Math.max(utilityValue.actualAspectRatio, options.desiredAspectRatio) * .5));
               if (weightedUtility > weigthFullnessAspectRatio) {
                 weigthFullnessAspectRatio = weightedUtility;
                 resultLocation.x = cell.x;
                 resultLocation.y = cell.y;
               }
-
             }
-
           }
         });
       }
@@ -551,12 +544,12 @@ var layoutUtilities = function (cy, options) {
     });
 
     var packingResult = {};
-    packingResult.shifts = []
+    packingResult.shifts = [];
 
     /*  var shiftX = componentsCenter.x - ((mainGrid.center.x - mainGrid.occupiedRectangle.x1)*gridStep); 
      var shiftY = componentsCenter.y - ((mainGrid.center.y - mainGrid.occupiedRectangle.y1)*gridStep); 
      var occupiedCenterX = Math.floor((mainGrid.occupiedRectangle.x1 + mainGrid.occupiedRectangle.x2)/2);
-     var occupiedCenterY = Math.floor((mainGrid.occupiedRectangle.y1 + mainGrid.occupiedRectangle.y2)/2); */7
+     var occupiedCenterY = Math.floor((mainGrid.occupiedRectangle.y1 + mainGrid.occupiedRectangle.y2)/2); */
     // Calculate the difference between old center and new center
     let rectCenter = mainGrid.occupiedRectangle.center();
     let renderedCenter = new Point(rectCenter.x * gridStep, rectCenter.y * gridStep);
@@ -585,7 +578,7 @@ var layoutUtilities = function (cy, options) {
 
 
     return packingResult;
-  }
+  };
 
   return instance;
 };

--- a/src/core/layout-utilities.js
+++ b/src/core/layout-utilities.js
@@ -560,8 +560,9 @@ var layoutUtilities = function (cy, options) {
       }
     });
 
-    var packingResult = {};
-    packingResult.shifts = [];
+    var packingResult = {
+      shifts: []
+    };
 
     /*  var shiftX = componentsCenter.x - ((mainGrid.center.x - mainGrid.occupiedRectangle.x1)*gridStep); 
      var shiftY = componentsCenter.y - ((mainGrid.center.y - mainGrid.occupiedRectangle.y1)*gridStep); 
@@ -582,10 +583,10 @@ var layoutUtilities = function (cy, options) {
     let centerShift = shiftedCenter.diff(currentCenter);
 
     // Add the center shift
-    packingResult.shifts.forEach((shift) => {
+    for (let shift of packingResult.shifts) {
       shift.dx += centerShift.x;
       shift.dy += centerShift.y;
-    });
+    }
 
     packingResult.aspectRatio = Math.round(((mainGrid.occupiedRectangle.x2 - mainGrid.occupiedRectangle.x1 + 1) / (mainGrid.occupiedRectangle.y2 - mainGrid.occupiedRectangle.y1 + 1)) * 1e2) / 1e2;
     packingResult.fullness = Math.round(((mainGrid.numberOfOccupiredCells / ((mainGrid.occupiedRectangle.x2 - mainGrid.occupiedRectangle.x1 + 1) * (mainGrid.occupiedRectangle.y2 - mainGrid.occupiedRectangle.y1 + 1))) * 100) * 1e2) / 1e2;

--- a/src/core/polyomino-packing.js
+++ b/src/core/polyomino-packing.js
@@ -3,8 +3,8 @@ class Polyomino {
      * @param { number } width width of the polyomino in pixels
      * @param { number } height height of the polyomino in pixels
      * @param { number } index index in according to the input
-     * @param { number } leftMostCoord
-     * @param { number } topMostCoord
+     * @param { number } x1
+     * @param { number } y1
      * @param { number } gridStep width and height of a grid square
      * 
      * @description 
@@ -17,7 +17,7 @@ class Polyomino {
      * Old width and height properties were containing actually width and height divided by grid step, so I thought stepWidth and
      * stepHeight are more convenient names for them. 
      */
-    constructor(width, height, index, leftMostCoord, topMostCoord, gridStep) {
+    constructor(x1, y1, width, height, gridStep, index) {
         this.width = width;
         this.height = height;
         this.gridStep = gridStep;
@@ -29,8 +29,8 @@ class Polyomino {
             }
         }
         this.index = index; //index of polyomino in the input of the packing function
-        this.leftMostCoord = leftMostCoord; //kept to determine the amount of shift in the output
-        this.topMostCoord = topMostCoord;//kept to determine the amount of shift in the output
+        this.x1 = x1; //kept to determine the amount of shift in the output
+        this.y1 = y1;//kept to determine the amount of shift in the output
         this.location = new Point(-1, -1);  //the grid cell coordinates where the polyomino was placed
         this.center = new Point(Math.floor(this.stepWidth / 2), Math.floor(this.stepHeight / 2));// center of polyomino
         this.numberOfOccupiredCells = 0;
@@ -48,6 +48,14 @@ class Polyomino {
      */
     get stepHeight() {
         return Math.floor(this.height / this.gridStep) + 1;
+    }
+
+    get x2() {
+        return this.x1 + this.width;
+    }
+
+    get y2() {
+        return this.y1 + this.height;
     }
 
     getBoundingRectangle() {
@@ -138,7 +146,13 @@ class Grid {
         this.center = new Point(Math.floor(this.stepWidth / 2), Math.floor(this.stepHeight / 2));
         this.occupiedRectangle = new BoundingRectangle(
             Number.MAX_VALUE, Number.MAX_VALUE, 
-            Number.MIN_VALUE, Number.MIN_VALUE);  // the bounding rectanble of the occupied cells in the grid
+            Number.MIN_VALUE, Number.MIN_VALUE
+        );  // the bounding rectanble of the occupied cells in the grid
+        /** Same with this.occupiedRectangle but contains the undivided coordinates */
+        this.occupiedRectangleReal = new BoundingRectangle(
+            Number.MAX_VALUE, Number.MAX_VALUE, 
+            Number.MIN_VALUE, Number.MIN_VALUE
+        );
         this.numberOfOccupiredCells = 0;
     }
 
@@ -276,22 +290,8 @@ class Grid {
 
         //update number of occupired cells
         this.numberOfOccupiredCells += polyomino.numberOfOccupiredCells;
-
-        let polyRect = polyomino.getBoundingRectangle();
-
-        if (polyRect.x1 < this.occupiedRectangle.x1) {
-            this.occupiedRectangle.x1 = polyRect.x1;
-        }
-        if (polyRect.x2 > this.occupiedRectangle.x2) {
-            this.occupiedRectangle.x2 = polyRect.x2;
-        }
-        if (polyRect.y1 < this.occupiedRectangle.y1) {
-            this.occupiedRectangle.y1 = polyRect.y1;
-        }
-        if (polyRect.y2 > this.occupiedRectangle.y2) {
-            this.occupiedRectangle.y2 = polyRect.y2;
-        }
-
+        
+        this.updateBounds(polyomino);
         
         //update bounding rectangle and reset visited cells to none
         /* let x1 = this.occupiedRectangle.x1, x2= this.occupiedRectangle.x2,
@@ -311,6 +311,23 @@ class Grid {
         this.occupiedRectangle.y1 = y1;
         this.occupiedRectangle.x2 = x2;
         this.occupiedRectangle.y2 = y2;   */ 
+    }
+
+    /**
+     * @param { Polyomino } polyomino
+     */
+    updateBounds(polyomino) {
+        let polyRect = polyomino.getBoundingRectangle();
+
+        this.occupiedRectangle.x1 = Math.min(this.occupiedRectangle.x1, polyRect.x1);
+        this.occupiedRectangle.x2 = Math.max(this.occupiedRectangle.x2, polyRect.x2);
+        this.occupiedRectangle.y1 = Math.min(this.occupiedRectangle.y1, polyRect.y1);
+        this.occupiedRectangle.y2 = Math.max(this.occupiedRectangle.y2, polyRect.y2);
+        
+        this.occupiedRectangleReal.x1 = Math.min(this.occupiedRectangleReal.x1, polyomino.x1);
+        this.occupiedRectangleReal.x2 = Math.max(this.occupiedRectangleReal.x2, polyomino.x2);
+        this.occupiedRectangleReal.y1 = Math.min(this.occupiedRectangleReal.y1, polyomino.y1);
+        this.occupiedRectangleReal.y2 = Math.max(this.occupiedRectangleReal.y2, polyomino.y2);
     }
 
     /**

--- a/src/core/polyomino-packing.js
+++ b/src/core/polyomino-packing.js
@@ -1,20 +1,53 @@
 class Polyomino {
-    constructor(width, height, index, leftMostCoord, topMostCoord) {
-        this.grid = new Array(width);
-        for (var i = 0; i < width; i++) {
-            this.grid[i] = new Array(height);
-            for (var j = 0; j < height; j++) {
+    /**
+     * @param { number } width width of the polyomino in pixels
+     * @param { number } height height of the polyomino in pixels
+     * @param { number } index index in according to the input
+     * @param { number } leftMostCoord
+     * @param { number } topMostCoord
+     * @param { number } gridStep width and height of a grid square
+     * 
+     * @description 
+     * Note: width and height are added to establish centering according to old layout center
+     * 
+     * Since width divided by the grid step can be calclated from raw step instead of adding new
+     * variables I changed width and height and added gridStep variable so that stepWith and stepHeight can be calculated
+     * from these. 
+     * 
+     * Old width and height properties were containing actually width and height divided by grid step, so I thought stepWidth and
+     * stepHeight are more convenient names for them. 
+     */
+    constructor(width, height, index, leftMostCoord, topMostCoord, gridStep) {
+        this.width = width;
+        this.height = height;
+        this.gridStep = gridStep;
+        this.grid = new Array(this.stepWidth);
+        for (var i = 0; i < this.stepWidth; i++) {
+            this.grid[i] = new Array(this.stepHeight);
+            for (var j = 0; j < this.stepHeight; j++) {
                 this.grid[i][j] = false;
             }
         }
         this.index = index; //index of polyomino in the input of the packing function
         this.leftMostCoord = leftMostCoord; //kept to determine the amount of shift in the output
         this.topMostCoord = topMostCoord;//kept to determine the amount of shift in the output
-        this.width = width;
-        this.height = height;
         this.location = new Point(-1, -1);  //the grid cell coordinates where the polyomino was placed
-        this.center = new Point(Math.floor(width / 2), Math.floor(height / 2));// center of polyomino
+        this.center = new Point(Math.floor(this.stepWidth / 2), Math.floor(this.stepHeight / 2));// center of polyomino
         this.numberOfOccupiredCells = 0;
+    }
+
+    /**
+     * width of the polyomino divided by grid steps
+     */
+    get stepWidth() {
+        return Math.floor(this.width / this.gridStep) + 1;
+    }
+
+    /**
+     * height of the polyomino divided by grid steps
+     */
+    get stepHeight() {
+        return Math.floor(this.height / this.gridStep) + 1;
     }
 
     getBoundingRectangle() {
@@ -24,13 +57,19 @@ class Polyomino {
         return new BoundingRectangle(
             polyx1,
             polyy1,
-            polyx1 + this.width,
-            polyy1 + this.height 
+            // -1 because if length == 1 then x2 == x1
+            polyx1 + this.stepWidth - 1,
+            polyy1 + this.stepHeight - 1 
         );
     }
 }
 
 class Point {
+    /**
+     * 
+     * @param { number } x 
+     * @param { number } y 
+     */
     constructor(x, y) {
         this.x = x;
         this.y = y;
@@ -49,6 +88,12 @@ class Point {
 }
 
 class BoundingRectangle {
+    /**
+     * @param { number } x1
+     * @param { number } y1
+     * @param { number } x2
+     * @param { number } y2
+     */
     constructor(x1, y1, x2, y2) {
         this.x1 = x1;
         this.x2 = x2;
@@ -65,37 +110,60 @@ class BoundingRectangle {
 }
 
 class Cell {
+    /**
+     * 
+     * @param { boolean } occupied 
+     * @param { boolean } visited 
+     */
     constructor(occupied, visited) {
         this.occupied = occupied; //boolean to determine if the cell is occupied
         this.visited = visited; //boolean to determine if the cell was visited before while traversing the cells
     }
 }
 class Grid {
-    constructor(width, height) {
+    /**
+     * 
+     * @param { number } width 
+     * @param { number } height 
+     * @param { number } step 
+     */
+    constructor(width, height, step) {
         this.width = width;
         this.height = height;
+        this.step = step;
         //create and intialize the grid
-        this.grid = new Array(width);
-        for (var i = 0; i < width; i++) {
-            this.grid[i] = new Array(height);
-            for (var j = 0; j < height; j++) {
-                this.grid[i][j] = new Cell(false, false);
-            }
-        }
-        this.center = new Point(Math.floor(width / 2), Math.floor(height / 2));
+        this.grid = Array.from({ length: this.stepWidth },
+            ((_) => Array.from({ length: this.stepHeight },
+                ((_) => new Cell(false, false)))));
+        this.center = new Point(Math.floor(this.stepWidth / 2), Math.floor(this.stepHeight / 2));
         this.occupiedRectangle = new BoundingRectangle(
-            Number.MAX_VALUE, Number.MAX_VALUE,
-            Number.MIN_VALUE, Number.MIN_VALUE
-        );  // the bounding rectanble of the occupied cells in the grid
+            Number.MAX_VALUE, Number.MAX_VALUE, 
+            Number.MIN_VALUE, Number.MIN_VALUE);  // the bounding rectanble of the occupied cells in the grid
         this.numberOfOccupiredCells = 0;
     }
 
-    //function given a list of cells it returns the direct unvisited unoccupied neighboring cells 
+    /**
+     * returns the width in terms of grid steps
+     */
+    get stepWidth() {
+        return Math.floor(this.width / this.step) + 1;
+    }
+
+    /**
+     * returns the height in terms of grid steps
+     */
+    get stepHeight() {
+        return Math.floor(this.height / this.step) + 1;
+    }
+
+    /**
+     * function given a list of cells it returns the direct unvisited unoccupied neighboring cells 
+     */
     getDirectNeighbors(cells, level) {
         var resultPoints = [];
         if (cells.length == 0) {
-            for (var i = 0; i < this.width; i++) {
-                for (var j = 0; j < this.height; j++) {
+            for (var i = 0; i < this.stepWidth; i++) {
+                for (var j = 0; j < this.stepHeight; j++) {
                     if (this.grid[i][j].occupied) {
                         resultPoints = resultPoints.concat(this.getCellNeighbors(i, j));
                     }
@@ -121,7 +189,11 @@ class Grid {
         return resultPoints;
     }
 
-    //given a cell at locatoin i,j get the unvistied unoccupied neighboring cell
+    /**
+     * given a cell at locatoin i,j get the unvistied unoccupied neighboring cell
+     * @param { number } i
+     * @param { number } j
+     */
     getCellNeighbors(i, j) {
         var resultPoints = [];
         //check all the 8 surrounding cells 
@@ -131,7 +203,7 @@ class Grid {
                 this.grid[i - 1][j].visited = true;
             }
         }
-        if (i + 1 < this.width) {
+        if (i + 1 < this.stepWidth) {
             if (!this.grid[i + 1][j].occupied && !this.grid[i + 1][j].visited) {
                 resultPoints.push({ x: i + 1, y: j });
                 this.grid[i + 1][j].visited = true;
@@ -143,7 +215,7 @@ class Grid {
                 this.grid[i][j - 1].visited = true;
             }
         }
-        if (j + 1 < this.height) {
+        if (j + 1 < this.stepHeight) {
             if (!this.grid[i][j + 1].occupied && !this.grid[i][j + 1].visited) {
                 resultPoints.push({ x: i, y: j + 1 });
                 this.grid[i][j + 1].visited = true;
@@ -162,20 +234,20 @@ class Grid {
             }
         }
 
-        if (i + 1 < this.width && j - 1 >= 0) {
+        if (i + 1 < this.stepWidth && j - 1 >= 0) {
             if (!this.grid[i + 1][j - 1].occupied && !this.grid[i + 1][j - 1].visited) {
                 resultPoints.push({ x: i + 1, y: j - 1 });
                 this.grid[i + 1][j - 1].visited = true;
             }
         }
 
-        if (i - 1 >= 0 && j + 1 < this.height) {
+        if (i - 1 >= 0 && j + 1 < this.stepHeight) {
             if (!this.grid[i - 1][j + 1].occupied && !this.grid[i - 1][j + 1].visited) {
                 resultPoints.push({ x: i - 1, y: j + 1 });
                 this.grid[i - 1][j + 1].visited = true;
             }
         }
-        if (i + 1 < this.width && j + 1 < this.height) {
+        if (i + 1 < this.stepWidth && j + 1 < this.stepHeight) {
             if (!this.grid[i + 1][j + 1].occupied && !this.grid[i + 1][j + 1].visited) {
                 resultPoints.push({ x: i + 1, y: j + 1 });
                 this.grid[i + 1][j + 1].visited = true;
@@ -185,12 +257,17 @@ class Grid {
         return resultPoints;
     }
 
-    // a function to place a given polyomino in the cell i j on the grid
+    /**
+     * a function to place a given polyomino in the cell i j on the grid
+     * @param { Polyomino } polyomino 
+     * @param { number } i 
+     * @param { number } j 
+     */
     placePolyomino(polyomino, i, j) {
         polyomino.location.x = i;
         polyomino.location.y = j;
-        for (let k = 0; k < polyomino.width; k++) {
-            for (let l = 0; l < polyomino.height; l++) {
+        for (let k = 0; k < polyomino.stepWidth; k++) {
+            for (let l = 0; l < polyomino.stepHeight; l++) {
                 if (polyomino.grid[k][l]) { //if [k] [l] cell is occupied in polyomino
                     this.grid[k - polyomino.center.x + i][l - polyomino.center.y + j].occupied = true;
                 }
@@ -215,20 +292,38 @@ class Grid {
             this.occupiedRectangle.y2 = polyRect.y2;
         }
 
+        
         //update bounding rectangle and reset visited cells to none
-        for (let x = 0; x < this.width; x++) {
-            for (let y = 0; y < this.height; y++) {
+        /* let x1 = this.occupiedRectangle.x1, x2= this.occupiedRectangle.x2,
+            y1 = this.occupiedRectangle.y1, y2= this.occupiedRectangle.y2; */
+        for (let x = 0; x < this.stepWidth; x++) {
+            for (let y = 0; y < this.stepHeight; y++) {
                 this.grid[x][y].visited = false;
+                /* if(this.grid[x][y].occupied){
+                    if(x <= x1) x1 = x;
+                    if(y <= y1) y1 = y;
+                    if(x >= x2) x2 = x;
+                    if(y >= y2) y2 = y;  
+                } */
             }
         }
+        /* this.occupiedRectangle.x1 = x1,
+        this.occupiedRectangle.y1 = y1;
+        this.occupiedRectangle.x2 = x2;
+        this.occupiedRectangle.y2 = y2;   */ 
     }
 
-    // a function to determine if a polyomino can be placed on the given cell i,j
+    /**
+     * a function to determine if a polyomino can be placed on the given cell i,j
+     * @param { Polyomino } polyomino 
+     * @param { number } i 
+     * @param { number } j 
+     */
     tryPlacingPolyomino(polyomino, i, j) {
-        for (var k = 0; k < polyomino.width; k++) {
-            for (var l = 0; l < polyomino.height; l++) {
+        for (var k = 0; k < polyomino.stepWidth; k++) {
+            for (var l = 0; l < polyomino.stepHeight; l++) {
                 //return false if polyomino goes outside the grid when placed on i,j
-                if (k - polyomino.center.x + i >= this.width || k - polyomino.center.x + i < 0 || l - polyomino.center.y + j >= this.height || l - polyomino.center.y + j < 0) {
+                if (k - polyomino.center.x + i >= this.stepWidth || k - polyomino.center.x + i < 0 || l - polyomino.center.y + j >= this.stepHeight || l - polyomino.center.y + j < 0) {
                     return false;
                 }
                 //return false if the  polymino cell and the corrosponding main grid cell are both occupied
@@ -240,7 +335,13 @@ class Grid {
         return true;
     }
 
-    //calculates the value of the utility (aspect ratio) of placing a polyomino on cell i,j
+    /**
+     * calculates the value of the utility (aspect ratio) of placing a polyomino on cell i,j
+     * @param { Polyomino } polyomino
+     * @param { number } i
+     * @param { number } j
+     * @param { number } desiredAspectRatio
+     */
     calculateUtilityOfPlacing(polyomino, i, j, desiredAspectRatio) {
         var result = {};
         var actualAspectRatio = 1;
@@ -252,8 +353,8 @@ class Grid {
         var y2 = this.occupiedRectangle.y2;
         if (i - polyomino.center.x < x1) x1 = i - polyomino.center.x;
         if (j - polyomino.center.y < y1) y1 = j - polyomino.center.y;
-        if (polyomino.width - 1 - polyomino.center.x + i > x2) x2 = polyomino.width - 1 - polyomino.center.x + i;
-        if (polyomino.height - 1 - polyomino.center.y + j > y2) y2 = polyomino.height - 1 - polyomino.center.y + j;
+        if (polyomino.stepWidth - 1 - polyomino.center.x + i > x2) x2 = polyomino.stepWidth - 1 - polyomino.center.x + i;
+        if (polyomino.stepHeight - 1 - polyomino.center.y + j > y2) y2 = polyomino.stepHeight - 1 - polyomino.center.y + j;
         var width = x2 - x1 + 1;
         var height = y2 - y1 + 1;
         actualAspectRatio = width / height;

--- a/src/core/polyomino-packing.js
+++ b/src/core/polyomino-packing.js
@@ -26,6 +26,17 @@ class Point{
         this.x = x;
         this.y = y;        
     }
+
+    /**
+     * Returns other - this for x and y
+     * @param { Point } other
+     */
+    diff(other) {
+        return new Point(
+            other.x - this.x,
+            other.y - this.y,
+        );
+    }
 }
 
 class BoundingRectangle{
@@ -34,6 +45,13 @@ class BoundingRectangle{
         this.x2 = x2;
         this.y1 = y1;
         this.y2 = y2;        
+    }
+
+    center() {
+        return new Point(
+            (this.x2 - this.x1) / 2, 
+            (this.y2 - this.y1) / 2,
+        );
     }
 }
 
@@ -56,7 +74,10 @@ class Grid{
             }
         }
         this.center = new Point(Math.floor(width/2), Math.floor(height/2));
-        this.occupiedRectangle = new BoundingRectangle(0,0,0,0);  // the bounding rectanble of the occupied cells in the grid
+        this.occupiedRectangle = new BoundingRectangle(
+            Number.MAX_VALUE, Number.MAX_VALUE,
+            Number.MIN_VALUE, Number.MIN_VALUE
+        );  // the bounding rectanble of the occupied cells in the grid
         this.numberOfOccupiredCells = 0;      
     }
 
@@ -170,10 +191,11 @@ class Grid{
                     this.grid[k-polyomino.center.x + i][l-polyomino.center.y + j].occupied = true;
                 }
             }
-        }
+        }        
+
         //update number of occupired cells
         this.numberOfOccupiredCells += polyomino.numberOfOccupiredCells;
-
+        
         //update bounding rectangle and reset visited cells to none
         var x1 = 10000, x2= 0,y1 = 10000,y2=0;
         for(var x = 0 ; x<this.width; x++){
@@ -190,8 +212,7 @@ class Grid{
         this.occupiedRectangle.x1 = x1,
         this.occupiedRectangle.y1 = y1;
         this.occupiedRectangle.x2 = x2;
-        this.occupiedRectangle.y2= y2;     
-      
+        this.occupiedRectangle.y2 = y2;   
     }
 
     // a function to determine if a polyomino can be placed on the given cell i,j

--- a/src/core/polyomino-packing.js
+++ b/src/core/polyomino-packing.js
@@ -154,7 +154,7 @@ class Grid {
         this.center = new Point(Math.floor(this.stepWidth / 2), Math.floor(this.stepHeight / 2));
         this.occupiedRectangle = new BoundingRectangle(
             Number.MAX_VALUE, Number.MAX_VALUE, 
-            Number.MIN_VALUE, Number.MIN_VALUE
+            -Number.MAX_VALUE, -Number.MAX_VALUE
         );  // the bounding rectanble of the occupied cells in the grid
         this.numberOfOccupiredCells = 0;
     }

--- a/src/core/polyomino-packing.js
+++ b/src/core/polyomino-packing.js
@@ -19,6 +19,18 @@ class Polyomino {
         this.center = new Point(Math.floor(width / 2), Math.floor(height / 2));// center of polyomino
         this.numberOfOccupiredCells = 0;
     }
+
+    getBoundingRectangle() {
+        const polyx1 = this.location.x - this.center.x; 
+        const polyy1 = this.location.y - this.center.y;
+
+        return new BoundingRectangle(
+            polyx1,
+            polyy1,
+            polyx1 + this.width,
+            polyy1 + this.height,   
+        );
+    }
 }
 
 class Point {
@@ -96,18 +108,14 @@ class Grid {
             var endIndex = resultPoints.length - 1;
 
             for (var i = 2; i <= level; i++) {
-
                 if (endIndex >= startIndex) {
                     for (var j = startIndex; j <= endIndex; j++) {
                         resultPoints = resultPoints.concat(this.getCellNeighbors(resultPoints[j].x, resultPoints[j].y));
                     }
                 }
-
                 startIndex = endIndex + 1;
                 endIndex = resultPoints.length - 1;
-
             }
-
         } else {
             cells.forEach(function (cell) {
                 resultPoints = resultPoints.concat(this.getCellNeighbors(cell.x, cell.y));
@@ -178,15 +186,14 @@ class Grid {
         }
 
         return resultPoints;
-
     }
 
     // a function to place a given polyomino in the cell i j on the grid
     placePolyomino(polyomino, i, j) {
         polyomino.location.x = i;
         polyomino.location.y = j;
-        for (var k = 0; k < polyomino.width; k++) {
-            for (var l = 0; l < polyomino.height; l++) {
+        for (let k = 0; k < polyomino.width; k++) {
+            for (let l = 0; l < polyomino.height; l++) {
                 if (polyomino.grid[k][l]) { //if [k] [l] cell is occupied in polyomino
                     this.grid[k - polyomino.center.x + i][l - polyomino.center.y + j].occupied = true;
                 }
@@ -196,23 +203,27 @@ class Grid {
         //update number of occupired cells
         this.numberOfOccupiredCells += polyomino.numberOfOccupiredCells;
 
+        let polyRect = polyomino.getBoundingRectangle();
+
+        if (polyRect.x1 < this.occupiedRectangle.x1) {
+            this.occupiedRectangle.x1 = polyRect.x1;
+        }
+        if (polyRect.x2 > this.occupiedRectangle.x2) {
+            this.occupiedRectangle.x2 = polyRect.x2;
+        }
+        if (polyRect.y1 < this.occupiedRectangle.y1) {
+            this.occupiedRectangle.y1 = polyRect.y1;
+        }
+        if (polyRect.y2 > this.occupiedRectangle.y2) {
+            this.occupiedRectangle.y2 = polyRect.y2;
+        }
+
         //update bounding rectangle and reset visited cells to none
-        var x1 = 10000, x2 = 0, y1 = 10000, y2 = 0;
-        for (var x = 0; x < this.width; x++) {
-            for (var y = 0; y < this.height; y++) {
+        for (let x = 0; x < this.width; x++) {
+            for (let y = 0; y < this.height; y++) {
                 this.grid[x][y].visited = false;
-                if (this.grid[x][y].occupied) {
-                    if (x <= x1) x1 = x;
-                    if (y <= y1) y1 = y;
-                    if (x >= x2) x2 = x;
-                    if (y >= y2) y2 = y;
-                }
             }
         }
-        this.occupiedRectangle.x1 = x1,
-            this.occupiedRectangle.y1 = y1;
-        this.occupiedRectangle.x2 = x2;
-        this.occupiedRectangle.y2 = y2;
     }
 
     // a function to determine if a polyomino can be placed on the given cell i,j
@@ -255,9 +266,7 @@ class Grid {
             adjustedFullness = (this.numberOfOccupiredCells + polyomino.numberOfOccupiredCells) / (width * (width / desiredAspectRatio));
             // height = width / desiredAspectRatio;
         } else {
-
             adjustedFullness = (this.numberOfOccupiredCells + polyomino.numberOfOccupiredCells) / ((height * desiredAspectRatio) * height);
-
             // width = height * desiredAspectRatio;
         }
 
@@ -266,9 +275,7 @@ class Grid {
         result.adjustedFullness = adjustedFullness;
 
         return result;
-
     }
-
 }
 
 module.exports = {

--- a/src/core/polyomino-packing.js
+++ b/src/core/polyomino-packing.js
@@ -32,6 +32,7 @@ class Polyomino {
         this.x1 = x1; //kept to determine the amount of shift in the output
         this.y1 = y1;//kept to determine the amount of shift in the output
         this.location = new Point(-1, -1);  //the grid cell coordinates where the polyomino was placed
+        /** inner center */
         this.center = new Point(Math.floor(this.stepWidth / 2), Math.floor(this.stepHeight / 2));// center of polyomino
         this.numberOfOccupiredCells = 0;
     }
@@ -56,6 +57,13 @@ class Polyomino {
 
     get y2() {
         return this.y1 + this.height;
+    }
+
+    /**
+     * returns the center relative to location inside the grid
+     */
+    get gridStepCenter() {
+        return this.center.diff(this.location);
     }
 
     getBoundingRectangle() {
@@ -128,9 +136,9 @@ class Cell {
         this.visited = visited; //boolean to determine if the cell was visited before while traversing the cells
     }
 }
+
 class Grid {
-    /**
-     * 
+    /** 
      * @param { number } width 
      * @param { number } height 
      * @param { number } step 
@@ -148,11 +156,6 @@ class Grid {
             Number.MAX_VALUE, Number.MAX_VALUE, 
             Number.MIN_VALUE, Number.MIN_VALUE
         );  // the bounding rectanble of the occupied cells in the grid
-        /** Same with this.occupiedRectangle but contains the undivided coordinates */
-        this.occupiedRectangleReal = new BoundingRectangle(
-            Number.MAX_VALUE, Number.MAX_VALUE, 
-            Number.MIN_VALUE, Number.MIN_VALUE
-        );
         this.numberOfOccupiredCells = 0;
     }
 
@@ -293,27 +296,16 @@ class Grid {
         
         this.updateBounds(polyomino);
         
-        //update bounding rectangle and reset visited cells to none
-        /* let x1 = this.occupiedRectangle.x1, x2= this.occupiedRectangle.x2,
-            y1 = this.occupiedRectangle.y1, y2= this.occupiedRectangle.y2; */
+        // reset visited cells to none
         for (let x = 0; x < this.stepWidth; x++) {
             for (let y = 0; y < this.stepHeight; y++) {
                 this.grid[x][y].visited = false;
-                /* if(this.grid[x][y].occupied){
-                    if(x <= x1) x1 = x;
-                    if(y <= y1) y1 = y;
-                    if(x >= x2) x2 = x;
-                    if(y >= y2) y2 = y;  
-                } */
             }
         }
-        /* this.occupiedRectangle.x1 = x1,
-        this.occupiedRectangle.y1 = y1;
-        this.occupiedRectangle.x2 = x2;
-        this.occupiedRectangle.y2 = y2;   */ 
     }
 
     /**
+     * Updates step rectangle bounds so that the `polyomino` fits
      * @param { Polyomino } polyomino
      */
     updateBounds(polyomino) {
@@ -323,11 +315,6 @@ class Grid {
         this.occupiedRectangle.x2 = Math.max(this.occupiedRectangle.x2, polyRect.x2);
         this.occupiedRectangle.y1 = Math.min(this.occupiedRectangle.y1, polyRect.y1);
         this.occupiedRectangle.y2 = Math.max(this.occupiedRectangle.y2, polyRect.y2);
-        
-        this.occupiedRectangleReal.x1 = Math.min(this.occupiedRectangleReal.x1, polyomino.x1);
-        this.occupiedRectangleReal.x2 = Math.max(this.occupiedRectangleReal.x2, polyomino.x2);
-        this.occupiedRectangleReal.y1 = Math.min(this.occupiedRectangleReal.y1, polyomino.y1);
-        this.occupiedRectangleReal.y2 = Math.max(this.occupiedRectangleReal.y2, polyomino.y2);
     }
 
     /**
@@ -398,7 +385,4 @@ module.exports = {
     Polyomino: Polyomino,
     BoundingRectangle: BoundingRectangle,
     Point: Point
-
 };
-
-

--- a/src/core/polyomino-packing.js
+++ b/src/core/polyomino-packing.js
@@ -2,11 +2,11 @@ var generalUtils = require('./general-utils');
 
 
 class Polyomino {
-    constructor(width,height,index,leftMostCoord,topMostCoord){        
+    constructor(width, height, index, leftMostCoord, topMostCoord) {
         this.grid = new Array(width);
         for (var i = 0; i < width; i++) {
             this.grid[i] = new Array(height);
-            for(var j = 0 ; j < height;j++){
+            for (var j = 0; j < height; j++) {
                 this.grid[i][j] = false;
             }
         }
@@ -15,16 +15,16 @@ class Polyomino {
         this.topMostCoord = topMostCoord;//kept to determine the amount of shift in the output
         this.width = width;
         this.height = height;
-        this.location = new Point(-1,-1);  //the grid cell coordinates where the polyomino was placed
-        this.center = new Point(Math.floor(width/2), Math.floor(height/2));// center of polyomino
-        this.numberOfOccupiredCells = 0;  
+        this.location = new Point(-1, -1);  //the grid cell coordinates where the polyomino was placed
+        this.center = new Point(Math.floor(width / 2), Math.floor(height / 2));// center of polyomino
+        this.numberOfOccupiredCells = 0;
     }
 }
 
-class Point{
-    constructor(x , y){
+class Point {
+    constructor(x, y) {
         this.x = x;
-        this.y = y;        
+        this.y = y;
     }
 
     /**
@@ -39,193 +39,193 @@ class Point{
     }
 }
 
-class BoundingRectangle{
-    constructor(x1,y1,x2,y2){
+class BoundingRectangle {
+    constructor(x1, y1, x2, y2) {
         this.x1 = x1;
         this.x2 = x2;
         this.y1 = y1;
-        this.y2 = y2;        
+        this.y2 = y2;
     }
 
     center() {
         return new Point(
-            (this.x2 - this.x1) / 2, 
+            (this.x2 - this.x1) / 2,
             (this.y2 - this.y1) / 2,
         );
     }
 }
 
-class Cell{
-    constructor(occupied,visited){
+class Cell {
+    constructor(occupied, visited) {
         this.occupied = occupied; //boolean to determine if the cell is occupied
         this.visited = visited; //boolean to determine if the cell was visited before while traversing the cells
     }
 }
-class Grid{
-    constructor(width, height){
+class Grid {
+    constructor(width, height) {
         this.width = width;
         this.height = height;
         //create and intialize the grid
         this.grid = new Array(width);
         for (var i = 0; i < width; i++) {
             this.grid[i] = new Array(height);
-            for(var j = 0 ; j < height;j++){
-                this.grid[i][j] = new Cell(false,false);
+            for (var j = 0; j < height; j++) {
+                this.grid[i][j] = new Cell(false, false);
             }
         }
-        this.center = new Point(Math.floor(width/2), Math.floor(height/2));
+        this.center = new Point(Math.floor(width / 2), Math.floor(height / 2));
         this.occupiedRectangle = new BoundingRectangle(
             Number.MAX_VALUE, Number.MAX_VALUE,
             Number.MIN_VALUE, Number.MIN_VALUE
         );  // the bounding rectanble of the occupied cells in the grid
-        this.numberOfOccupiredCells = 0;      
+        this.numberOfOccupiredCells = 0;
     }
 
     //function given a list of cells it returns the direct unvisited unoccupied neighboring cells 
-    getDirectNeighbors(cells, level){
+    getDirectNeighbors(cells, level) {
         var resultPoints = [];
-        if(cells.length == 0){
-            for(var i = 0 ; i< this.width;i++){
-                for(var j = 0 ; j< this.height;j++){
-                    if(this.grid[i][j].occupied){                       
-                       resultPoints = resultPoints.concat(this.getCellNeighbors(i,j));
+        if (cells.length == 0) {
+            for (var i = 0; i < this.width; i++) {
+                for (var j = 0; j < this.height; j++) {
+                    if (this.grid[i][j].occupied) {
+                        resultPoints = resultPoints.concat(this.getCellNeighbors(i, j));
                     }
                 }
             }
-            var startIndex = 0 ;
-            var endIndex = resultPoints.length -1 ;
-            
-            for(var i = 2 ; i<=level ; i++){
-               
-                if(endIndex >= startIndex){
-                    for(var j = startIndex ; j<= endIndex ; j++){
-                        resultPoints = resultPoints.concat(this.getCellNeighbors(resultPoints[j].x,resultPoints[j].y));
+            var startIndex = 0;
+            var endIndex = resultPoints.length - 1;
+
+            for (var i = 2; i <= level; i++) {
+
+                if (endIndex >= startIndex) {
+                    for (var j = startIndex; j <= endIndex; j++) {
+                        resultPoints = resultPoints.concat(this.getCellNeighbors(resultPoints[j].x, resultPoints[j].y));
                     }
-                }             
-                
-                startIndex = endIndex +1;
+                }
+
+                startIndex = endIndex + 1;
                 endIndex = resultPoints.length - 1;
 
             }
 
-        }else{
-            cells.forEach(function(cell){
-                    resultPoints = resultPoints.concat(this.getCellNeighbors(cell.x,cell.y));
+        } else {
+            cells.forEach(function (cell) {
+                resultPoints = resultPoints.concat(this.getCellNeighbors(cell.x, cell.y));
             }.bind(this));
         }
         return resultPoints;
     }
 
     //given a cell at locatoin i,j get the unvistied unoccupied neighboring cell
-    getCellNeighbors(i,j){
+    getCellNeighbors(i, j) {
         var resultPoints = [];
         //check all the 8 surrounding cells 
-        if(i-1 >= 0){
-            if(!this.grid[i-1][j].occupied && !this.grid[i-1][j].visited) {
-                resultPoints.push({x: i-1, y:j});   
-                this.grid[i-1][j].visited = true;              
-            }                        
-        }
-        if(i+1 < this.width){
-            if(!this.grid[i+1][j].occupied && !this.grid[i+1][j].visited) {
-                resultPoints.push({x: i+1, y:j});
-                this.grid[i+1][j].visited= true;
+        if (i - 1 >= 0) {
+            if (!this.grid[i - 1][j].occupied && !this.grid[i - 1][j].visited) {
+                resultPoints.push({ x: i - 1, y: j });
+                this.grid[i - 1][j].visited = true;
             }
         }
-        if(j-1 >= 0){
-            if(!this.grid[i][j-1].occupied && !this.grid[i][j-1].visited) {
-                resultPoints.push({x: i, y:j-1});
-                this.grid[i][j-1].visited= true;
+        if (i + 1 < this.width) {
+            if (!this.grid[i + 1][j].occupied && !this.grid[i + 1][j].visited) {
+                resultPoints.push({ x: i + 1, y: j });
+                this.grid[i + 1][j].visited = true;
             }
         }
-        if(j+1 < this.height){
-            if(!this.grid[i][j+1].occupied && !this.grid[i][j+1].visited) {
-                resultPoints.push({x: i, y:j+1});
-                this.grid[i][j+1].visited= true;
+        if (j - 1 >= 0) {
+            if (!this.grid[i][j - 1].occupied && !this.grid[i][j - 1].visited) {
+                resultPoints.push({ x: i, y: j - 1 });
+                this.grid[i][j - 1].visited = true;
             }
         }
-        if(i-1 >= 0){
-            if(!this.grid[i-1][j].occupied && !this.grid[i-1][j].visited) {
-                resultPoints.push({x: i-1, y:j});
-                this.grid[i-1][j].visited= true;
+        if (j + 1 < this.height) {
+            if (!this.grid[i][j + 1].occupied && !this.grid[i][j + 1].visited) {
+                resultPoints.push({ x: i, y: j + 1 });
+                this.grid[i][j + 1].visited = true;
             }
         }
-        if(i-1 >=0 && j-1 >=0){
-            if(!this.grid[i-1][j-1].occupied && !this.grid[i-1][j-1].visited) {
-                resultPoints.push({x: i-1, y:j-1});
-                this.grid[i-1][j-1].visited= true;
+        if (i - 1 >= 0) {
+            if (!this.grid[i - 1][j].occupied && !this.grid[i - 1][j].visited) {
+                resultPoints.push({ x: i - 1, y: j });
+                this.grid[i - 1][j].visited = true;
             }
         }
-
-        if(i+1 < this.width && j-1 >=0){
-            if(!this.grid[i+1][j-1].occupied && !this.grid[i+1][j-1].visited) {
-                resultPoints.push({x: i+1, y:j-1});
-                this.grid[i+1][j-1].visited= true;
+        if (i - 1 >= 0 && j - 1 >= 0) {
+            if (!this.grid[i - 1][j - 1].occupied && !this.grid[i - 1][j - 1].visited) {
+                resultPoints.push({ x: i - 1, y: j - 1 });
+                this.grid[i - 1][j - 1].visited = true;
             }
         }
 
-        if(i-1 >= 0 && j+1 < this.height){
-            if(!this.grid[i-1][j+1].occupied && !this.grid[i-1][j+1].visited) {
-                resultPoints.push({x: i-1, y:j+1});
-                this.grid[i-1][j+1].visited= true;
+        if (i + 1 < this.width && j - 1 >= 0) {
+            if (!this.grid[i + 1][j - 1].occupied && !this.grid[i + 1][j - 1].visited) {
+                resultPoints.push({ x: i + 1, y: j - 1 });
+                this.grid[i + 1][j - 1].visited = true;
             }
         }
-        if(i+1 < this.width && j+1 < this.height){
-            if(!this.grid[i+1][j+1].occupied && !this.grid[i+1][j+1].visited) {
-                resultPoints.push({x: i+1, y:j+1});
-                this.grid[i+1][j+1].visited = true;
+
+        if (i - 1 >= 0 && j + 1 < this.height) {
+            if (!this.grid[i - 1][j + 1].occupied && !this.grid[i - 1][j + 1].visited) {
+                resultPoints.push({ x: i - 1, y: j + 1 });
+                this.grid[i - 1][j + 1].visited = true;
+            }
+        }
+        if (i + 1 < this.width && j + 1 < this.height) {
+            if (!this.grid[i + 1][j + 1].occupied && !this.grid[i + 1][j + 1].visited) {
+                resultPoints.push({ x: i + 1, y: j + 1 });
+                this.grid[i + 1][j + 1].visited = true;
             }
         }
 
         return resultPoints;
-        
+
     }
 
     // a function to place a given polyomino in the cell i j on the grid
-    placePolyomino(polyomino, i , j){
+    placePolyomino(polyomino, i, j) {
         polyomino.location.x = i;
         polyomino.location.y = j;
-        for(var k = 0 ; k< polyomino.width; k++){
-            for(var l = 0 ; l < polyomino.height; l++){
-                if(polyomino.grid[k][l]){ //if [k] [l] cell is occupied in polyomino
-                    this.grid[k-polyomino.center.x + i][l-polyomino.center.y + j].occupied = true;
+        for (var k = 0; k < polyomino.width; k++) {
+            for (var l = 0; l < polyomino.height; l++) {
+                if (polyomino.grid[k][l]) { //if [k] [l] cell is occupied in polyomino
+                    this.grid[k - polyomino.center.x + i][l - polyomino.center.y + j].occupied = true;
                 }
             }
-        }        
+        }
 
         //update number of occupired cells
         this.numberOfOccupiredCells += polyomino.numberOfOccupiredCells;
-        
+
         //update bounding rectangle and reset visited cells to none
-        var x1 = 10000, x2= 0,y1 = 10000,y2=0;
-        for(var x = 0 ; x<this.width; x++){
-            for(var y = 0 ; y< this.height;y++){
+        var x1 = 10000, x2 = 0, y1 = 10000, y2 = 0;
+        for (var x = 0; x < this.width; x++) {
+            for (var y = 0; y < this.height; y++) {
                 this.grid[x][y].visited = false;
-                if(this.grid[x][y].occupied){
-                    if(x <= x1) x1 = x;
-                    if(y <= y1) y1 = y;
-                    if(x >= x2) x2 = x;
-                    if(y >= y2) y2 = y;  
+                if (this.grid[x][y].occupied) {
+                    if (x <= x1) x1 = x;
+                    if (y <= y1) y1 = y;
+                    if (x >= x2) x2 = x;
+                    if (y >= y2) y2 = y;
                 }
             }
         }
         this.occupiedRectangle.x1 = x1,
-        this.occupiedRectangle.y1 = y1;
+            this.occupiedRectangle.y1 = y1;
         this.occupiedRectangle.x2 = x2;
-        this.occupiedRectangle.y2 = y2;   
+        this.occupiedRectangle.y2 = y2;
     }
 
     // a function to determine if a polyomino can be placed on the given cell i,j
-    tryPlacingPolyomino(polyomino, i , j){     
-        for(var k = 0 ; k< polyomino.width; k++){
-            for(var l = 0 ; l < polyomino.height; l++){
+    tryPlacingPolyomino(polyomino, i, j) {
+        for (var k = 0; k < polyomino.width; k++) {
+            for (var l = 0; l < polyomino.height; l++) {
                 //return false if polyomino goes outside the grid when placed on i,j
-                if(k-polyomino.center.x + i >= this.width || k-polyomino.center.x + i < 0 || l-polyomino.center.y + j >= this.height ||  l-polyomino.center.y + j < 0){
+                if (k - polyomino.center.x + i >= this.width || k - polyomino.center.x + i < 0 || l - polyomino.center.y + j >= this.height || l - polyomino.center.y + j < 0) {
                     return false;
                 }
                 //return false if the  polymino cell and the corrosponding main grid cell are both occupied
-                if(polyomino.grid[k][l] &&  this.grid[k-polyomino.center.x + i][l-polyomino.center.y + j].occupied){
-                   return false;
+                if (polyomino.grid[k][l] && this.grid[k - polyomino.center.x + i][l - polyomino.center.y + j].occupied) {
+                    return false;
                 }
             }
         }
@@ -233,50 +233,50 @@ class Grid{
     }
 
     //calculates the value of the utility (aspect ratio) of placing a polyomino on cell i,j
-    calculateUtilityOfPlacing(polyomino, i , j,desiredAspectRatio){
-       var result = {} ;
-       var actualAspectRatio = 1;
-       var fullness = 1;
-       var adjustedFullness = 1;
-       var x1 = this.occupiedRectangle.x1;
-       var x2 = this.occupiedRectangle.x2;
-       var y1 = this.occupiedRectangle.y1;
-       var y2 = this.occupiedRectangle.y2;
-       if(i - polyomino.center.x < x1) x1 = i - polyomino.center.x ;
-       if(j - polyomino.center.y < y1) y1 = j - polyomino.center.y;
-       if(polyomino.width - 1 - polyomino.center.x + i > x2) x2 = polyomino.width - 1 - polyomino.center.x + i;
-       if(polyomino.height -1 - polyomino.center.y + j > y2) y2 = polyomino.height -1 - polyomino.center.y + j; 
-        var width = x2-x1 + 1;
-        var height = y2-y1 + 1;
-        actualAspectRatio = width/height;
+    calculateUtilityOfPlacing(polyomino, i, j, desiredAspectRatio) {
+        var result = {};
+        var actualAspectRatio = 1;
+        var fullness = 1;
+        var adjustedFullness = 1;
+        var x1 = this.occupiedRectangle.x1;
+        var x2 = this.occupiedRectangle.x2;
+        var y1 = this.occupiedRectangle.y1;
+        var y2 = this.occupiedRectangle.y2;
+        if (i - polyomino.center.x < x1) x1 = i - polyomino.center.x;
+        if (j - polyomino.center.y < y1) y1 = j - polyomino.center.y;
+        if (polyomino.width - 1 - polyomino.center.x + i > x2) x2 = polyomino.width - 1 - polyomino.center.x + i;
+        if (polyomino.height - 1 - polyomino.center.y + j > y2) y2 = polyomino.height - 1 - polyomino.center.y + j;
+        var width = x2 - x1 + 1;
+        var height = y2 - y1 + 1;
+        actualAspectRatio = width / height;
         fullness = (this.numberOfOccupiredCells + polyomino.numberOfOccupiredCells) / (width * height);
 
-        if(actualAspectRatio > desiredAspectRatio){
-            adjustedFullness = (this.numberOfOccupiredCells + polyomino.numberOfOccupiredCells) / (width* (width/desiredAspectRatio));
-           // height = width / desiredAspectRatio;
-        }else{
+        if (actualAspectRatio > desiredAspectRatio) {
+            adjustedFullness = (this.numberOfOccupiredCells + polyomino.numberOfOccupiredCells) / (width * (width / desiredAspectRatio));
+            // height = width / desiredAspectRatio;
+        } else {
 
-            adjustedFullness = (this.numberOfOccupiredCells + polyomino.numberOfOccupiredCells) / ((height* desiredAspectRatio)* height);
+            adjustedFullness = (this.numberOfOccupiredCells + polyomino.numberOfOccupiredCells) / ((height * desiredAspectRatio) * height);
 
-           // width = height * desiredAspectRatio;
+            // width = height * desiredAspectRatio;
         }
 
         result.actualAspectRatio = actualAspectRatio;
         result.fullness = fullness;
         result.adjustedFullness = adjustedFullness;
-        
-      return result;
+
+        return result;
 
     }
-    
+
 }
 
 module.exports = {
     Grid: Grid,
-    Polyomino : Polyomino,
-    BoundingRectangle : BoundingRectangle,
-    Point : Point
-    
-  };
+    Polyomino: Polyomino,
+    BoundingRectangle: BoundingRectangle,
+    Point: Point
+
+};
 
 

--- a/src/core/polyomino-packing.js
+++ b/src/core/polyomino-packing.js
@@ -1,6 +1,3 @@
-var generalUtils = require('./general-utils');
-
-
 class Polyomino {
     constructor(width, height, index, leftMostCoord, topMostCoord) {
         this.grid = new Array(width);
@@ -28,7 +25,7 @@ class Polyomino {
             polyx1,
             polyy1,
             polyx1 + this.width,
-            polyy1 + this.height,   
+            polyy1 + this.height 
         );
     }
 }
@@ -46,7 +43,7 @@ class Point {
     diff(other) {
         return new Point(
             other.x - this.x,
-            other.y - this.y,
+            other.y - this.y
         );
     }
 }
@@ -62,7 +59,7 @@ class BoundingRectangle {
     center() {
         return new Point(
             (this.x2 - this.x1) / 2,
-            (this.y2 - this.y1) / 2,
+            (this.y2 - this.y1) / 2
         );
     }
 }


### PR DESCRIPTION
This PR adds the feature request #18 

Changes:
* `instance.packComponents` now moves the components in such a way that their center of the bounding rectangle is retained

The feature is implemented like this:
1- calculate the center of the bounding rectangle before any layout operation (traverses all nodes)
2- after the packing, calculate the new bounding rectangle (also traverses all nodes)
3- for each node we add the differences of the centers to their respective shift amount

Traversing each node shouldn't change the runtime cost since algorithm already does that.