### PR TITLE
new heuristic for placing new nodes

### DIFF
--- a/cytoscape-layout-utilities.js
+++ b/cytoscape-layout-utilities.js
@@ -768,56 +768,6 @@ var layoutUtilities = function (cy, options) {
     return this.filterByScratchProp({nodes: node.siblings(), prop: 'calculated', value: true });
   };
 
-  instance.placeNewNodesNewHeuristic = function (newNodes) {
-    // Remove temporary extension data remained from prior operations
-    cy.nodes().forEach(node => node.removeScratch(extensionName));
-    
-    const currentNodes = cy.nodes(':visible').difference(newNodes);
-    currentNodes.forEach(node => this.setScratchProp({node, prop: 'calculated', value: true}));
-    const maxRank = this.rankNodes(newNodes, currentNodes);
-    const postponedNodes = [];
-    for (let i = 0; i <= maxRank; i++) {
-      let compounds = [];
-      for (const node of this.filterByScratchProp({nodes: newNodes, prop: 'rank', value: i})) {
-        if (node.isParent()) {
-          compounds.push(node);
-        } else if (node.isChild() && newNodes.contains(node.parent())) {
-          // If it is inside a new node, escalate its neighbors to parent
-          const escalatedNeighbors = this.getScratchProp({node: node.parent(), prop: 'escalatedNeighbors', defaultValue: [] });
-          this.setScratchProp({node: node.parent(), prop: 'escalatedNeighbors', value: [...escalatedNeighbors, ...this.getCalculatedNeighbors(node)]})
-        } else if (i === 0 && node.neighborhood().nodes().length !== 0 && node.isOrphan()) {
-          // Postpone this type of nodes since their neighbors will be placed after
-          postponedNodes.push(node);
-        } else {
-          this.setOptimumPosition(node);
-        }
-      }
-      compounds = this.sortByHierarchy(compounds);
-      for (const node of compounds) {
-        const escalatedNeighbors = this.getScratchProp({node, prop: 'escalatedNeighbors', defaultValue: [] });
-        if (node.isChild() && newNodes.contains(node.parent())) {
-          // If this compound node is inside another new node, escalete the neighbors to parent
-          const parentNeighbors = this.getScratchProp({node: node.parent(), prop: 'escalatedNeighbors', defaultValue: [] });
-          this.setScratchProp({node: node.parent(), prop: 'escalatedNeighbors', value: [...parentNeighbors, ...this.getCalculatedNeighbors(node), ...escalatedNeighbors]})
-        } else {
-          // Calculate optimum position of the compound node with respect to siblings and neighbors
-          const siblings = this.getCalculatedSiblings(node)
-          const siblingPositions = siblings.map(e => e.position());
-          const siblingAvg = this.getAvgPos(siblingPositions);
-
-          const uniqueNeighbors = [...new Set([...escalatedNeighbors, ...this.getCalculatedNeighbors(node)])];
-          const neighborsAvg = this.getAvgPos(uniqueNeighbors.map(e => e.position()));
-          
-          const calculatedAvgPos = this.getSiblingNeighborAverage(siblingAvg, neighborsAvg);
-          this.placeCompoundNode(node, calculatedAvgPos, options.idealEdgeLength);
-        }
-      }
-    }
-    for (const node of postponedNodes) {
-      this.setOptimumPosition(node);
-    }
-  };
-
   /** Get an average point between siblings average and neighbors average, with respect to siblingWeight */
   instance.getSiblingNeighborAverage = function (siblingAvg, neighborsAvg) {
     switch (true) {
@@ -988,211 +938,61 @@ var layoutUtilities = function (cy, options) {
     }
     return maxRank;
   };
-  
+
   instance.placeHiddenNodes = function (mainEles) {
     mainEles.forEach(function (mainEle) {
       var hiddenEles = mainEle.neighborhood().nodes(":hidden");
-      hiddenEles.forEach(function (hiddenEle) {
-        var neighbors = hiddenEle.neighborhood().nodes(":visible");
-        if (neighbors.length > 1) {
-          instance.nodeWithMultipleNeighbors(hiddenEle);
-        } else instance.nodeWithOneNeighbor(mainEle, hiddenEle);
-      });
+      instance.placeNewNodes(hiddenEles);
     });
   };
 
-  instance.placeNewNodes = function (eles) {
-    var components = this.findComponents(eles);
-    var disconnectedComp = [];
-    for (var i = 0; i < components.length; i++) {
-      var oneNeig = false;
-      var multNeig = false;
-      var mainEle;
-      var multneighbors = [];
-      var positioned = [];
-      var x = 0;
-      var y = 0;
-      var isPositioned = false;
-      for (var j = 0; j < components[i].length; j++) {
-        var neighbors = components[i][j].neighborhood().nodes().difference(eles);
-        positioned.push(false);
-        if (neighbors.length > 1 && !isPositioned) {
-          multNeig = true;
-          positioned[j] = true;
-          multneighbors = neighbors;
-          instance.nodeWithMultipleNeighbors(components[i][j], multneighbors);
-          x = components[i][j].position("x");
-          y = components[i][j].position("y");
-          isPositioned = true;
-        }
-        else if (neighbors.length == 1 && !isPositioned) {
-          oneNeig = true;
-          mainEle = neighbors[0];
-          positioned[j] = true;
-          instance.nodeWithOneNeighbor(mainEle, components[i][j], eles);
-          x = components[i][j].position("x");
-          y = components[i][j].position("y");
-          isPositioned = true;
+  instance.placeNewNodes = function (newNodes) {
+    // Remove temporary extension data remained from prior operations
+    cy.nodes().forEach(node => node.removeScratch(extensionName));
+    
+    const currentNodes = cy.nodes(':visible').difference(newNodes);
+    currentNodes.forEach(node => this.setScratchProp({node, prop: 'calculated', value: true}));
+    const maxRank = this.rankNodes(newNodes, currentNodes);
+    const postponedNodes = [];
+    for (let i = 0; i <= maxRank; i++) {
+      let compounds = [];
+      for (const node of this.filterByScratchProp({nodes: newNodes, prop: 'rank', value: i})) {
+        if (node.isParent()) {
+          compounds.push(node);
+        } else if (node.isChild() && newNodes.contains(node.parent())) {
+          // If it is inside a new node, escalate its neighbors to parent
+          const escalatedNeighbors = this.getScratchProp({node: node.parent(), prop: 'escalatedNeighbors', defaultValue: [] });
+          this.setScratchProp({node: node.parent(), prop: 'escalatedNeighbors', value: [...escalatedNeighbors, ...this.getCalculatedNeighbors(node)]})
+        } else if (i === 0 && node.neighborhood().nodes().length !== 0 && node.isOrphan()) {
+          // Postpone this type of nodes since their neighbors will be placed after
+          postponedNodes.push(node);
+        } else {
+          this.setOptimumPosition(node);
         }
       }
+      compounds = this.sortByHierarchy(compounds);
+      for (const node of compounds) {
+        const escalatedNeighbors = this.getScratchProp({node, prop: 'escalatedNeighbors', defaultValue: [] });
+        if (node.isChild() && newNodes.contains(node.parent())) {
+          // If this compound node is inside another new node, escalete the neighbors to parent
+          const parentNeighbors = this.getScratchProp({node: node.parent(), prop: 'escalatedNeighbors', defaultValue: [] });
+          this.setScratchProp({node: node.parent(), prop: 'escalatedNeighbors', value: [...parentNeighbors, ...this.getCalculatedNeighbors(node), ...escalatedNeighbors]})
+        } else {
+          // Calculate optimum position of the compound node with respect to siblings and neighbors
+          const siblings = this.getCalculatedSiblings(node)
+          const siblingPositions = siblings.map(e => e.position());
+          const siblingAvg = this.getAvgPos(siblingPositions);
 
-      if (oneNeig || multNeig) {
-        for (var j = 0; j < components[i].length; j++) {
-          if (positioned[j] == false) {
-            var neighbors = components[i][j].neighborhood().nodes();
-            var positionedNeigbors = [];
-            var curr = components[i][j].neighborhood().nodes().difference(eles);
-            curr.forEach(function (ele) {
-              positionedNeigbors.push(ele);
-            })
-
-            for (var k = 0; k < neighbors.length; k++) {
-              if (positioned[components[i].indexOf(neighbors[k])]) {
-                positionedNeigbors.push(neighbors[k]);
-              }
-            }
-            if (positionedNeigbors.length > 1) {
-              instance.nodeWithMultipleNeighbors(components[i][j], positionedNeigbors);
-            } else if (positionedNeigbors.length == 1) instance.nodeWithOneNeighbor(positionedNeigbors[0], components[i][j]);
-            else {
-              var horizontalP = instance.generateRandom(options.offset, options.offset * 2, 0);
-              var verticalP = instance.generateRandom(options.offset, options.offset * 2, 0);
-              components[i][j].position("x", x + horizontalP);
-              components[i][j].position("y", y + verticalP);
-            }
-            positioned[j] = true;
-          }
+          const uniqueNeighbors = [...new Set([...escalatedNeighbors, ...this.getCalculatedNeighbors(node)])];
+          const neighborsAvg = this.getAvgPos(uniqueNeighbors.map(e => e.position()));
+          
+          const calculatedAvgPos = this.getSiblingNeighborAverage(siblingAvg, neighborsAvg);
+          this.placeCompoundNode(node, calculatedAvgPos, options.idealEdgeLength);
         }
-      }
-      else {
-        disconnectedComp.push(components[i]);
       }
     }
-
-    if (disconnectedComp.length >= 1) {
-      instance.disconnectedNodes(disconnectedComp);
-    }
-  };
-
-  instance.disconnectedNodes = function (components) {
-    var leftX = Number.MAX_VALUE;
-    var rightX = -Number.MAX_VALUE;
-    var topY = Number.MAX_VALUE;
-    var bottomY = -Number.MAX_VALUE;
-    // Check the x and y limits of all hidden elements and store them in the variables above
-    cy.nodes(':visible').forEach(function (node) {
-      var halfWidth = node.outerWidth() / 2;
-      var halfHeight = node.outerHeight() / 2;
-      if (node.position("x") - halfWidth < leftX)
-        leftX = node.position("x") - halfWidth;
-      if (node.position("x") + halfWidth > rightX)
-        rightX = node.position("x") + halfWidth;
-      if (node.position("y") - halfHeight < topY)
-        topY = node.position("y") - halfHeight;
-      if (node.position("y") + halfHeight > bottomY)
-        bottomY = node.position("y") + halfHeight;
-    });
-
-    var radiusy = topY - bottomY;
-    var radiusx = rightX - leftX;
-    var innerRadius = (Math.sqrt(radiusx * radiusx + radiusy * radiusy)) / 2;
-    var centerX = (leftX + rightX) / 2;
-    var centerY = (topY + bottomY) / 2;
-    //var components = this.findComponents(newEles);
-    var numOfComponents = components.length;
-    var angle = 360 / numOfComponents;
-    var count = 1;
-
-    components.forEach(function (component) {
-
-      var distFromCenter = instance.generateRandom(innerRadius + options.offset * 6, innerRadius + options.offset * 8, 1);
-      var curAngle = angle * count;
-      var angleInRadians = curAngle * Math.PI / 180;
-      var x = centerX + distFromCenter * Math.cos(angleInRadians);
-      var y = centerY + distFromCenter * Math.sin(angleInRadians);
-
-      if (component.length == 1) {
-        component[0].position("x", x);
-        component[0].position("y", y);
-      }
-      else {
-        var positioned = [];
-        for (var i = 0; i < component.length; i++) {
-          positioned.push(false);
-        }
-
-        positioned[0] = true;
-        component[0].position("x", x);
-        component[0].position("y", y);
-
-        for (var i = 1; i < component.length; i++) {
-          var neighbors = component[i].neighborhood().nodes();
-          var positionedNeigbors = [];
-          for (var j = 0; j < neighbors.length; j++) {
-            if (positioned[component.indexOf(neighbors[j])]) {
-              positionedNeigbors.push(neighbors[j]);
-            }
-          }
-          if (positionedNeigbors.length > 1) {
-            instance.nodeWithMultipleNeighbors(component[i], positionedNeigbors);
-          } else if (positionedNeigbors.length == 1) instance.nodeWithOneNeighbor(positionedNeigbors[0], component[i]);
-          else {
-            var horizontalP = instance.generateRandom(options.offset, options.offset * 2, 0);
-            var verticalP = instance.generateRandom(options.offset, options.offset * 2, 0);
-            component[i].position("x", x + horizontalP);
-            component[i].position("y", y + verticalP);
-          }
-          positioned[i] = true;
-        }
-      }
-      count++;
-    });
-  };
-
-  instance.findComponents = function (newEles) {
-
-    var adjListArray = [];
-    var current = cy.nodes().difference(newEles);
-    newEles.forEach(function (ele) {
-      var neighbors = ele.neighborhood().nodes().difference(current);
-      var listOfIndexes = [];
-      neighbors.forEach(function (neigbor) {
-        var index = newEles.indexOf(neigbor);
-        listOfIndexes.push(index);
-      });
-      adjListArray.push(listOfIndexes);
-    });
-
-    // Mark all the vertices as not visited 
-    var visited = [];
-    for (var v = 0; v < newEles.length; v++) {
-      visited.push(false);
-    }
-
-    var listOfComponents = [];
-
-
-    for (var v = 0; v < newEles.length; v++) {
-      var elesOfComponent = [];
-      if (visited[v] == false) {
-        // print all reachable vertices 
-        // from v 
-        this.DFSUtil(v, visited, adjListArray, newEles, elesOfComponent);
-        listOfComponents.push(elesOfComponent);
-      }
-    }
-
-    return listOfComponents;
-  };
-
-  instance.DFSUtil = function (v, visited, adjListArray, newEles, elesOfComponent) {
-    // Mark the current node as visited and print it 
-    visited[v] = true;
-    elesOfComponent.push(newEles[v]);
-    // Recur for all the vertices 
-    // adjacent to this vertex 
-    for (var i = 0; i < adjListArray[v].length; i++) {
-      if (!visited[adjListArray[v][i]]) this.DFSUtil(adjListArray[v][i], visited, adjListArray, newEles, elesOfComponent);
+    for (const node of postponedNodes) {
+      this.setOptimumPosition(node);
     }
   };
 
@@ -1259,26 +1059,6 @@ var layoutUtilities = function (cy, options) {
     var newCenterY = mainEle.position("y") + verticalParam;
     unplacedEle.position("x", newCenterX);
     unplacedEle.position("y", newCenterY);
-  };
-
-  instance.nodeWithMultipleNeighbors = function (ele, neighbors) {
-    if (neighbors == null) {
-      var neighbors = ele.neighborhood().nodes(":visible");
-    }
-    var x = 0;
-    var y = 0;
-    var count = 0;
-    neighbors.forEach(function (ele1) {
-      x += ele1.position("x");
-      y += ele1.position("y");
-      count++;
-    });
-    x = x / count;
-    y = y / count;
-    var diffx = instance.generateRandom(0, options.offset / 2, 0);
-    var diffy = instance.generateRandom(0, options.offset / 2, 0);
-    ele.position("x", x + diffx);
-    ele.position("y", y + diffy);
   };
 
   instance.generateRandom = function (min, max, mult) {

--- a/cytoscape-layout-utilities.js
+++ b/cytoscape-layout-utilities.js
@@ -381,59 +381,59 @@ class Grid {
      * @param { number } j 
      * @param {boolean} considerAsPolygons Consider whether count the grid cells inside the face for calculating fullness or not 
      */
-     placePolyomino(polyomino, i, j, considerAsPolygons = true) {
-      polyomino.location.x = i;
-      polyomino.location.y = j;
+    placePolyomino(polyomino, i, j, considerAsPolygons = true) {
+        polyomino.location.x = i;
+        polyomino.location.y = j;
 
-      var horizontal = new Array(polyomino.stepHeight);
+        var horizontal = new Array(polyomino.stepHeight);
 
-      for(var k = 0; k < polyomino.stepHeight; k++){
-          horizontal[k] = new Array(2);
-          horizontal[k][0] = -1;
-          horizontal[k][1] = -1;
-      }
+        for(var k = 0; k < polyomino.stepHeight; k++){
+            horizontal[k] = new Array(2);
+            horizontal[k][0] = -1;
+            horizontal[k][1] = -1;
+        }
 
-      //vertical & horizontal coordinates
-      for (let k = 0; k < polyomino.stepWidth; k++) {
-          for (let l = 0; l < polyomino.stepHeight; l++) {
-              if(polyomino.grid[k][l]){
-                  if(horizontal[l][0] == -1)
-                      horizontal[l][0] = k;
-                  else
-                      horizontal[l][1] = k;
-              }
-          }
-      }
+        //Horizontal coordinates
+        for (let k = 0; k < polyomino.stepWidth; k++) {
+            for (let l = 0; l < polyomino.stepHeight; l++) {
+                if(polyomino.grid[k][l]){
+                    if(horizontal[l][0] == -1)
+                        horizontal[l][0] = k;
+                    else
+                        horizontal[l][1] = k;
+                }
+            }
+        }
 
-      // fill the horizontal line
-      for(let k = 0; k < polyomino.stepHeight;k++){
-          for(let l = horizontal[k][0]; l <= horizontal[k][1] && horizontal[k][0] != -1; l++){
-            if(considerAsPolygons && !polyomino.grid[l][k])
-              polyomino.numberOfOccupiredCells++;  
-            polyomino.grid[l][k] = true;
-          }
-      }
+        // fill the horizontal line
+        for(let k = 0; k < polyomino.stepHeight;k++){
+            for(let l = horizontal[k][0]; l <= horizontal[k][1] && horizontal[k][0] != -1; l++){
+                if(considerAsPolygons && !polyomino.grid[l][k])
+                    polyomino.numberOfOccupiredCells++;
+                polyomino.grid[l][k] = true;
+            }
+        }
 
-      for (let k = 0; k < polyomino.stepWidth; k++) {
-          for (let l = 0; l < polyomino.stepHeight; l++) {
-              if (polyomino.grid[k][l]) { //if [k] [l] cell is occupied in polyomino
-                  this.grid[k - polyomino.center.x + i][l - polyomino.center.y + j].occupied = true;
-              }
-          }
-      }
+        for (let k = 0; k < polyomino.stepWidth; k++) {
+            for (let l = 0; l < polyomino.stepHeight; l++) {
+                if (polyomino.grid[k][l]) { //if [k] [l] cell is occupied in polyomino
+                    this.grid[k - polyomino.center.x + i][l - polyomino.center.y + j].occupied = true;
+                }
+            }
+        }
 
-      //update number of occupired cells
-      this.numberOfOccupiredCells += polyomino.numberOfOccupiredCells;
-      
-      this.updateBounds(polyomino);
-      
-      // reset visited cells to none
-      for (let x = 0; x < this.stepWidth; x++) {
-          for (let y = 0; y < this.stepHeight; y++) {
-              this.grid[x][y].visited = false;
-          }
-      }
-  }
+        //update number of occupired cells
+        this.numberOfOccupiredCells += polyomino.numberOfOccupiredCells;
+        
+        this.updateBounds(polyomino);
+        
+        // reset visited cells to none
+        for (let x = 0; x < this.stepWidth; x++) {
+            for (let y = 0; y < this.stepHeight; y++) {
+                this.grid[x][y].visited = false;
+            }
+        }
+    }
 
     /**
      * Updates step rectangle bounds so that the `polyomino` fits
@@ -737,6 +737,225 @@ var layoutUtilities = function (cy, options) {
     options[name] = val;
   };
 
+  instance.placeNewNodesNewHeuristic = function (newNodes) {
+    const currentNodes = cy.nodes(':visible').difference(newNodes);
+    currentNodes.forEach(node => node.data('calculated', true));
+    const maxRank = this.rankNodes(newNodes, currentNodes);
+    const postponedNodes = [];
+    for (let i = 0; i <= maxRank; i++) {
+      let compounds = [];
+      for (const node of newNodes.filter(`node[rank=${i}]`)) {
+        if (node.isParent()) {
+          compounds.push(node);
+        } else if (node.isChild() && newNodes.contains(node.parent())) {
+          // If it is inside a new node, escalate its neighbors to parent
+          const neighbors = node.neighborhood().nodes().filter('node[calculated]');
+          const escalatedNeighbors = node.parent().data('escalatedNeighbors');
+          node.parent().data('escalatedNeighbors', [...(escalatedNeighbors || []), ...neighbors]);
+        } else if (i === 0 && node.neighborhood().nodes().length !== 0 && node.isOrphan()) {
+          // Postpone this type of nodes since their neighbors will be placed after
+          postponedNodes.push(node);
+        } else {
+          this.setOptimumPosition(node);
+        }
+      }
+      compounds = this.sortByHierarchy(compounds);
+      for (const node of compounds) {
+        if (node.isChild() && newNodes.contains(node.parent())) {
+          // If this compound node is inside another new node, escalete the neighbors to parent
+          const escalatedNeighbors = node.parent().data('escalatedNeighbors');
+          const nodesNeighbors = node.neighborhood().filter('node[calculated]');
+          node.parent().data('escalatedNeighbors', [...(escalatedNeighbors || []), 
+                                                    ...nodesNeighbors,
+                                                    ...(node.data('escalatedNeighbors') || [])]);
+        } else {
+          // Calculate optimum position of the compound node with respect to siblings and neighbors
+          const siblingPositions = node.siblings().filter('node[calculated]').map(e => e.position());
+          const siblingAvg = this.getAvgPos(siblingPositions);
+
+          const neighbors = [...node.data('escalatedNeighbors'), ...node.neighborhood().filter('node[calculated]')];
+          const uniqueNeighbors = [...new Set(neighbors)];
+          const neighborsAvg = this.getAvgPos(uniqueNeighbors.map(e => e.position()));
+          
+          const calculatedAvgPos = this.getSiblingNeighborAverage(siblingAvg, neighborsAvg);
+          this.placeCompoundNode(node, calculatedAvgPos, options.idealEdgeLength);
+        }
+      }
+    }
+    for (const node of postponedNodes) {
+      this.setOptimumPosition(node);
+    }
+  };
+
+  /** Get an average point between siblings average and neighbors average, with respect to siblingWeight */
+  instance.getSiblingNeighborAverage = function (siblingAvg, neighborsAvg) {
+    switch (true) {
+      case !!siblingAvg && !!neighborsAvg:
+        return {
+          x: siblingAvg.x * options.siblingWeight + neighborsAvg.x * (1 - options.siblingWeight),
+          y: siblingAvg.y * options.siblingWeight + neighborsAvg.y * (1 - options.siblingWeight)
+        };
+      case !!siblingAvg:
+        return siblingAvg;
+      case !!neighborsAvg:
+        return neighborsAvg;
+      default:
+        return {
+          x: cy.width() * -0.4,
+          y: cy.height() * -0.4
+        };
+    }
+  };
+
+  /** 
+   * Get the coordinates of a point between source and target, 
+   * where distance between point and source is offset 
+   */
+  instance.getWeightedMiddlePoint = function (source, target, offset) {
+    const calculateDistance = function (a, b) {
+      return Math.sqrt(Math.pow(Math.abs(a.x - b.x), 2) + Math.pow(Math.abs(a.y - b.y), 2));
+    };
+    if (target) {
+      const distance = calculateDistance(source, target);
+      if (distance) {
+        const ratio = offset / distance;
+        const highX = source.x > target.x ? -1 : 1;
+        const highY = source.y > target.y ? -1 : 1;
+        return {
+          x: source.x + highX * ratio * Math.abs(target.x - source.x),
+          y: source.y + highY * ratio * Math.abs(target.y - source.y)
+        }
+      }
+    }
+    return source;
+  };
+
+  /** Recursive function for placing the elements of a new node */
+  instance.placeCompoundNode = function (placedNode, coordinate, offset) {
+    const getOptimumPos = function (node, coordinate, offset) {
+      // Calculate the optimum position according to the average point of the neighbors and suggested coordinate
+      const allNeighbors = [...node.neighborhood().filter('node[calculated]'), ...(node.data('escalatedNeighbors') || [])];
+      const neighborsAvg = this.getAvgPos(allNeighbors.map(e => e.position()));
+      const weightedMiddlePoint = this.getWeightedMiddlePoint(coordinate, neighborsAvg, offset);
+      return this.getPositionWithOffset(weightedMiddlePoint, offset);
+    }.bind(this);
+    const postponedCompounds = [];
+    for (const node of placedNode.children()) {
+      if (node.isParent()) {
+        // Place compound nodes after placing all simple nodes
+        postponedCompounds.push(node);
+      } else {
+        node.position(getOptimumPos(node, coordinate, offset));
+        node.data('calculated', true);
+      }
+    }
+    for (const node of postponedCompounds) {
+      this.placeCompoundNode(node, getOptimumPos(node, coordinate, offset), offset / 2);
+    }
+    placedNode.data('calculated', true);
+  };
+
+  /** Sort given nodes so that most inner compound will come first in the sorted list */
+  instance.sortByHierarchy = function (nodes) {
+    let newNodes = [...nodes]; // deep copy
+    for (const node of nodes) {
+      const selfIndex = newNodes.findIndex(e => e.id() === node.id());
+      const parentIndex = newNodes.findIndex(e => e.id() === node.parent().id());
+      if (parentIndex !== -1 && parentIndex < selfIndex) {
+        const temp = newNodes[selfIndex];
+        newNodes[selfIndex] = newNodes[parentIndex];
+        newNodes[parentIndex] = temp;
+      }
+    }
+    return newNodes;
+  }
+
+  /** Get average position of given coordinates */
+  instance.getAvgPos = function (positions) {
+    if (positions.length === 0) return false;
+    const {xTotal, yTotal} = positions.reduce((acc, position) => {
+      const {x, y} = position;
+      acc.xTotal += x;
+      acc.yTotal += y;
+      return acc;
+    }, {xTotal: 0, yTotal: 0});
+    return {x: xTotal / positions.length, y: yTotal / positions.length};
+  }
+
+  /** Get new position whose distance to original one is offset */
+  instance.getPositionWithOffset = function(position, offset = options.offset) {
+    if (!position) {
+      position = {
+        x: cy.width() * -0.4,
+        y: cy.height() * -0.4
+      };
+    }
+    return {
+      x: position.x + this.generateRandom(0, offset / 2, 0),
+      y: position.y + this.generateRandom(0, offset / 2, 0),
+    }
+  };
+
+  instance.setOptimumPosition = function (node) {
+    const siblings = node.siblings().filter('node[calculated]');
+    const neighbors = node.neighborhood().filter('node[calculated]');
+
+    const siblingAvg = this.getAvgPos(siblings.map(e => e.position()));
+    const neighborsAvg = this.getAvgPos(neighbors.map(e => e.position()));
+
+    if (siblingAvg && !neighborsAvg && siblings.length === 1) {
+      this.nodeWithOneNeighbor(siblings[0], node);
+    } else if (neighborsAvg && !siblingAvg && neighbors.length === 1) {
+      this.nodeWithOneNeighbor(neighbors[0], node);
+    } else {
+      const newPosition = this.getSiblingNeighborAverage(siblingAvg, neighborsAvg);
+      node.position(this.getPositionWithOffset(newPosition));
+    }
+    node.data('calculated', true);
+  };
+
+  instance.rankNodes = function (newNodes, currentNodes) {
+    const unrankedNodes = newNodes.filter(node => !node.isParent());
+    const n = unrankedNodes.length;
+    let maxRank = 0;
+    let iteration = 0;
+    while (unrankedNodes.length > 0 && iteration < n) {
+      for (let j = unrankedNodes.length - 1; j >= 0; j--) {
+        const node = unrankedNodes[j];
+        let calculatedRank = -1;
+
+        const neighborNodes = node.neighborhood().nodes();
+        const ranksOfNeighbors = neighborNodes.filter('node[rank]').map(e => e.data('rank'));
+        if (neighborNodes.intersection(currentNodes).length > 0) {
+          calculatedRank = 1;
+        } else if (ranksOfNeighbors.length > 0) {
+          calculatedRank = Math.min(...ranksOfNeighbors) + 1;
+        }
+
+        if (calculatedRank !== -1) {
+          node.data("rank", calculatedRank);
+          maxRank = Math.max(maxRank, calculatedRank);
+          for (const anc of node.ancestors()) {
+            anc.data("rank", Math.max(anc.data("rank") || 0, calculatedRank));
+          }
+          unrankedNodes.splice(j, 1);
+        }
+      }
+      iteration++;
+    }
+    // If all n iterations are done and there are still unrankedNodes, it means that
+    // they should be rank 0
+    for (const node of unrankedNodes) {
+      node.data("rank", 0);
+      for (const anc of node.ancestors()) {
+        if (!anc.data("rank")) {
+          anc.data("rank", 0);
+        }
+      }
+    }
+    return maxRank;
+  };
+  
   instance.placeHiddenNodes = function (mainEles) {
     mainEles.forEach(function (mainEle) {
       var hiddenEles = mainEle.neighborhood().nodes(":hidden");
@@ -1073,10 +1292,9 @@ var layoutUtilities = function (cy, options) {
   /**
    * @param { any[] } components 
    * @param {boolean} considerAsPolygons include the empty cells inside the components to calculate how well the algorithm perform
-   * considerAsPolygons is false by default so the algorithm looks nonempty area/total area
+   * considerAsPolygons is false by default so the algorithm looks how well the free cells (outside the polyomino) is used
    */
   instance.packComponents = function (components, randomize = true, considerAsPolygons = false) {
-    
     var spacingAmount = options.componentSpacing;
     
     if(spacingAmount !== undefined) { // is spacingAmount is undefined, we expect it to be an incremental packing
@@ -1163,6 +1381,7 @@ var layoutUtilities = function (cy, options) {
           //bottom right cell of a node
           var bottomRightX = Math.floor((node.x + node.width - x1) / gridStep);
           var bottomRightY = Math.floor((node.y + node.height - y1) / gridStep);
+          
           for(var i = topLeftX; i <= bottomRightX; i++) {
             componentPolyomino.grid[i][topLeftY] = true;
             componentPolyomino.grid[i][bottomRightY] = true;
@@ -1180,6 +1399,7 @@ var layoutUtilities = function (cy, options) {
             }
           }
         });
+
         //fill cells where edges pass
         component.edges.forEach(function (edge) {
           var p0 = {}, p1 = {};

--- a/demo.html
+++ b/demo.html
@@ -66,9 +66,9 @@
     }
 
     #cy {
-      width: 80%;
+      width: calc((4 * 100% - 154px) / 5);
       height: 95%;
-      left: 21%;
+      right: 0%;
       top: 0%;
       float: left;
       overflow: hidden;

--- a/demo.html
+++ b/demo.html
@@ -221,26 +221,25 @@
         elements: {
           nodes: [
             { data: { id: 'n7', name: 'n7' } },
-            { data: { id: 'n6', name: 'n6', parent: 'n29' } },
+            { data: { id: 'n6', name: 'n6' } },
             { data: { id: 'n5', name: 'n5' } },
             { data: { id: 'n8', name: 'n8' } },
             { data: { id: 'n9', name: 'n9' } },
             { data: { id: 'n10', name: 'n10' } },
             { data: { id: 'n11', name: 'n11' } },
-            { data: { id: 'n12', name: 'n12' } },
+            { data: { id: 'n12', name: 'n12', parent: 'n29' } },
             { data: { id: 'n13', name: 'n13', parent: 'n29' } },
-            { data: { id: 'n14', name: 'n14' } },
-            { data: { id: 'n15', name: 'n15' } },
+            { data: { id: 'n14', name: 'n14', parent: 'n29' } },
+            { data: { id: 'n15', name: 'n15', parent: 'n29' } },
             { data: { id: 'n16', name: 'n16' } },
             { data: { id: 'n17', name: 'n17' } },
             { data: { id: 'n18', name: 'n18' } },
             { data: { id: 'n19', name: 'n19' } },
             { data: { id: 'n20', name: 'n20' } },
             { data: { id: 'n21', name: 'n21' } },
-
             { data: { id: 'n22', name: 'n22' } },
             { data: { id: 'n23', name: 'n23' } },
-            { data: { id: 'n24', name: 'n24', parent: 'n29' } },
+            { data: { id: 'n24', name: 'n24' } },
             { data: { id: 'n25', name: 'n25' } },
             { data: { id: 'n26', name: 'n26' } },
             { data: { id: 'n27', name: 'n27' } },
@@ -315,6 +314,102 @@
         return eles;
       }
 
+      function getTopMostNodes(nodes) {
+        let nodesMap = {};
+        for (let i = 0; i < nodes.length; i++) {
+            nodesMap[nodes[i].id()] = true;
+        }
+        let roots = nodes.filter(function (ele, i) {
+            if(typeof ele === "number") {
+              ele = i;
+            }
+            let parent = ele.parent()[0];
+            while(parent != null){
+              if(nodesMap[parent.id()]){
+                return false;
+              }
+              parent = parent.parent()[0];
+            }
+            return true;
+        });
+
+        return roots;
+      };
+
+      findComponents = function(topMostNodes){
+        let queue = [];
+        let visited = new Set();
+        let visitedTopMostNodes = [];
+        let currentNeighbor;
+
+        let allComponentsTraversed = false;
+        let components = [];
+
+        do {
+          let cmpt = cy.collection();
+          components.push(cmpt);
+
+          let currentNode = topMostNodes[0];
+          let childrenOfCurrentNode = cy.collection();
+          childrenOfCurrentNode.merge(currentNode).merge(currentNode.descendants());
+          visitedTopMostNodes.push(currentNode);
+
+          childrenOfCurrentNode.forEach(function(node) {
+            queue.push(node);
+            visited.add(node);
+            cmpt.merge(node);
+          });
+
+          while(queue.length != 0){
+            currentNode = queue.shift();
+
+            // Traverse all neighbors of this node
+            let neighborNodes = cy.collection();
+            currentNode.neighborhood().nodes().forEach(function(node){
+                neighborNodes.merge(node);
+            });
+
+            for(let i = 0; i < neighborNodes.length; i++){
+              let neighborNode = neighborNodes[i];
+              currentNeighbor = topMostNodes.intersection(neighborNode.union(neighborNode.ancestors()));
+              if(currentNeighbor != null && !visited.has(currentNeighbor[0])){
+                let childrenOfNeighbor = currentNeighbor.union(currentNeighbor.descendants());
+                childrenOfNeighbor.forEach(function(node){
+                  queue.push(node);
+                  visited.add(node);
+                  cmpt.merge(node);
+                  if(topMostNodes.has(node)){
+                    visitedTopMostNodes.push(node);
+                  }
+                });
+              }
+            }
+          }
+
+          cmpt.forEach(node => {
+            node.connectedEdges().forEach(e => { // connectedEdges() usually cached
+              if( cmpt.has(e.source()) && cmpt.has(e.target()) ){ // has() is cheap
+                cmpt.merge(e); // forEach() only considers nodes -- sets N at call time
+              }
+            });
+          });
+
+          if(visitedTopMostNodes.length == topMostNodes.length){
+            allComponentsTraversed = true;
+          }
+
+          let temp = cy.collection();
+          visitedTopMostNodes.forEach(function(node){
+            temp.merge(node);
+          });
+          visitedTopMostNodes = [];
+          topMostNodes = topMostNodes.difference(temp);
+        }
+        while(!allComponentsTraversed);
+
+        return components;
+      };
+
       $("#polyominoPack").click(function () {
         
         api.setOption("desiredAspectRatio", parseFloat($('#desiredAspectRatio').val()));
@@ -322,7 +417,8 @@
         api.setOption("utilityFunction", parseInt($('#utilityFunctionType').val()));
         api.setOption("componentSpacing", (document.getElementById('auto-spacing').checked ? undefined : parseInt($('#componentSpacing').val())));
         
-        var components = cy.elements(":visible").components();
+        var topMostNodes = getTopMostNodes(cy.nodes());
+        var components = findComponents(topMostNodes);
         var subgraphs = [];
         components.forEach(function (component) {
           var subgraph = {};
@@ -636,13 +732,14 @@
     <button id="addRandomNeighbors" class="button">Add random neighbors to selected</button>
     <br /> <br />      
 
-    <form>
+    <form style="margin-bottom: 0px;">
       <p style="position: relative;">
         <label for="layout" style="vertical-align:middle;">
           Rearrange on changes
         </label>
         <input type="checkbox" class="input" id="layout" name="layout" style="vertical-align:middle;" value="checked" checked>
       </p>
+      <br/>
       <p>
         <label for="siblingWeight">Sibling Weight</label>
         <input id="siblingWeight" style="width:60px; margin-bottom: 10px!important;" type="number" step="0.25"
@@ -668,14 +765,12 @@
         <input id="averageChildrenCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
           min="0" max="10" value="2">
       </p>
-      <br/>
       <p>
         <label for="newNodeCount">New Node Count</label>
         <input id="newNodeCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
           min="0" max="10" value="2">
       </p>
     </form>
-
 
     <div style="display: flex;">
       <span style="background-color: #8FE388; width: 16px; height: 16px; margin-right: 10px;"></span>

--- a/demo.html
+++ b/demo.html
@@ -169,7 +169,23 @@
             selector: 'node',
             style: {
               'content': 'data(name)',
-              'border-color': 'grey',
+              'border-color': function(ele) {
+                const { rank = -1 } = ele.scratch('layout_utilities') || {};
+                switch (rank) {
+                  case -1:
+                    return 'grey';
+                  case 0:
+                    return '#8FE388';
+                  case 1:
+                    return '#D36135';
+                  case 2:
+                    return '#279AF1';
+                  case 3:
+                    return '#89043D';
+                  default:
+                    return 'black';
+                }
+              },
               'border-width': 3,
               'background-color': 'lightgrey'
             }
@@ -205,14 +221,14 @@
         elements: {
           nodes: [
             { data: { id: 'n7', name: 'n7' } },
-            { data: { id: 'n6', name: 'n6' } },
+            { data: { id: 'n6', name: 'n6', parent: 'n29' } },
             { data: { id: 'n5', name: 'n5' } },
             { data: { id: 'n8', name: 'n8' } },
             { data: { id: 'n9', name: 'n9' } },
             { data: { id: 'n10', name: 'n10' } },
             { data: { id: 'n11', name: 'n11' } },
             { data: { id: 'n12', name: 'n12' } },
-            { data: { id: 'n13', name: 'n13' } },
+            { data: { id: 'n13', name: 'n13', parent: 'n29' } },
             { data: { id: 'n14', name: 'n14' } },
             { data: { id: 'n15', name: 'n15' } },
             { data: { id: 'n16', name: 'n16' } },
@@ -224,11 +240,12 @@
 
             { data: { id: 'n22', name: 'n22' } },
             { data: { id: 'n23', name: 'n23' } },
-            { data: { id: 'n24', name: 'n24' } },
+            { data: { id: 'n24', name: 'n24', parent: 'n29' } },
             { data: { id: 'n25', name: 'n25' } },
             { data: { id: 'n26', name: 'n26' } },
             { data: { id: 'n27', name: 'n27' } },
             { data: { id: 'n28', name: 'n28' } },
+            { data: { id: 'n29', name: 'n29' } },
 
           ],
           edges: [
@@ -271,7 +288,8 @@
           desiredAspectRatio: parseFloat($('#desiredAspectRatio').val()),
           polyominoGridSizeFactor: parseFloat($('#gridSizeFactor').val()),
           utilityFunction: parseInt($('#utilityFunctionType').val()),
-          componentSpacing: (document.getElementById('auto-spacing').checked ? undefined : parseInt($('#componentSpacing').val()))
+          componentSpacing: (document.getElementById('auto-spacing').checked ? undefined : parseInt($('#componentSpacing').val())),
+          siblingWeight: parseFloat($('#siblingWeight').val())
         }
       );
       var api2 = cy.viewUtilities();
@@ -280,7 +298,8 @@
         name: 'fcose',
         randomize: false,
         fit: false,
-        packComponents: false
+        packComponents: false,
+        nodeDimensionsIncludeLabels: true
       };
 
       function changeBorder(eles) {
@@ -365,6 +384,18 @@
         }
       });
 
+      document.getElementById('siblingWeight').addEventListener('change', function(e) {
+        api.setOption("siblingWeight", parseFloat(e.target.value));
+      });
+
+      $('#recalculateLayout').click(function() {
+        cy.layout(layoutOptions).run();
+      })
+
+      $('#performLayout').click(function() {
+        cy.layout({...layoutOptions, randomize: true}).run();
+      })
+
       $("#showHiddenNeighbors").click(function () {
         var nodesWithHiddenNeighbor = cy.edges(":hidden").connectedNodes(':visible');
         revertBorder(nodesWithHiddenNeighbor);
@@ -395,61 +426,145 @@
       
       var newNodeCounter = 0;
 
-      $("#addRandomNeighbors").click(function () {
-        var selectedNodes = cy.nodes(":selected");
-        var newNodesAll = cy.collection();
-        
-        selectedNodes.forEach(function(node){
-          var newNodesForSelected = cy.collection();
-          var randomNeighborCount = Math.floor(1 + 5*Math.random());
-          // for each selected node, add random nodes and connect them to the selected node
-          for(var i=0; i < randomNeighborCount; i++) {
-            var nodeId = node.id() + "_n" + newNodeCounter;
-            var edgeId = node.id() + "_e" + newNodeCounter;
-            var newEles = cy.add([
-              { group: 'nodes', data: { id: nodeId, name: node.css("content")}},
-              { group: 'edges', data: { id: edgeId, source: node.id(), target: nodeId } }
-            ]);                       
-            newNodeCounter++;
-            newNodesAll.merge(newEles.nodes());
-            newNodesForSelected.merge(newEles.nodes());
+      function getNewNodes() {
+        const nodeCount = parseInt($('#newNodeCount').val());
+        const averageDegree = parseInt($('#averageDegree').val());
+        const newNodes = cy.collection();
+        const currentNodes = cy.nodes();
+        const compoundNodes = cy.nodes().filter(e => e.isParent());
+        let newCompound;
+        for (let nodeId = 0; nodeId < nodeCount; nodeId++) {
+          const id = `n${window.iteration}-${nodeId}`;
+          const edgeId = `e${window.iteration}-${nodeId}`;
+          let parentID;
+          switch (Math.ceil(Math.random() * 3)) {
+            case 1: // New parent
+              if (newNodes.length === 0) {
+                newNodes.merge(cy.add({group: 'nodes', data: {id: `${id}a`, name: `${id}a`}}));
+              }
+              if (!newCompound) {
+                const randomNewCompound = newNodes[Math.floor(Math.random() * newNodes.length)];
+                newCompound = randomNewCompound;
+              }
+              parentID = newCompound.id();
+              break;
+            case 2: // Existing parent
+              parentID = compoundNodes[Math.floor(Math.random() * compoundNodes.length)].id()
+              break;
+            case 3: // No parent
+            default:
+              break;
           }
-          
-          var currentColor = adjust(rgbToHex(node.numericStyle("background-color")), -50);
-          newNodesForSelected.css("background-color", currentColor);           
-          
-          // add random edges between newly added nodes
-          if(newNodesForSelected.length > 1) {
-            var randomEdgeCount = Math.floor(newNodesForSelected.length * Math.random());
-            var newEdgeIds = new Set();
-            for(var i=0; i < randomEdgeCount; i++) {
-              var index1 = Math.floor(newNodesForSelected.length * Math.random());
-              var index2 = Math.floor(newNodesForSelected.length * Math.random());
-              if(index1 == index2 && (index2 + 1 < newNodesForSelected.length)){
-                index2++;
+          const newNode = cy.add({ group: 'nodes', data: { id, name: id, parent: parentID }});
+          newNodes.merge(newNode);
+
+          let neighborCount;
+          let selectedNodes = cy.nodes(":selected");
+          switch (Math.ceil(Math.random() * 6)) {
+            case 1:
+              if (selectedNodes.length === 0) {
+                neighborCount = 0;
+                break;
               }
-              if(index1 == index2 && (index2 - 1 >= 0)){
-                index2--;
+            case 2:
+              neighborCount = 1;
+              break;
+            default:
+              neighborCount = averageDegree;
+              break;
+          }
+
+          if (neighborCount) {
+            const addDummyNodes = function(dummyNodeCount, currentNodes) {
+              let nodeToConnect = currentNodes[Math.floor(Math.random() * currentNodes.length)];
+              for (let i = 0; i < dummyNodeCount; i++) {
+                    // Add necessary dummy nodes
+                    const dummyID = `${id}-d${i}`;
+                    const dummyNode = cy.add({ group: 'nodes', data: { id: dummyID, name: dummyID}});
+                    cy.add({ group: 'edges', data: { id: `${dummyID}-e`, source: nodeToConnect.id(), target: dummyID }})
+                    nodeToConnect = dummyNode;
+                    newNodes.merge(dummyNode)
+                    availableNewNodes.merge(dummyNode)
+                  }
+            }
+            const forbiddenNodes = cy.collection();
+            forbiddenNodes.merge(newNode);
+            forbiddenNodes.merge(newNode.ancestors());
+            forbiddenNodes.merge(newNode.descendants());
+            const availableNewNodes = newNodes.difference(forbiddenNodes)
+            const availableCurrentNodes = selectedNodes.length > 0 ? selectedNodes : currentNodes.difference(forbiddenNodes)
+            const selectedNeighbors = [];
+
+            const randomValue = Math.ceil(Math.random() * 10);
+            if (randomValue < 6 && selectedNodes.length === 0) {
+              const dummyNodeCount = neighborCount - availableNewNodes.length;
+              addDummyNodes(dummyNodeCount, availableCurrentNodes);
+              for (let i = 0; i < neighborCount; i++) {
+                let randomNeighbor;
+                if (i === 0) {
+                  // Select the last new node in any case, in order to increase the probability of higher rank nodes
+                  randomNeighbor = availableNewNodes[availableNewNodes.length - 1];
+                } else {
+                  do {
+                    randomNeighbor = availableNewNodes[Math.floor(Math.random() * availableNewNodes.length)];
+                  } while (selectedNeighbors.includes(randomNeighbor.id()));
+                }
+                selectedNeighbors.push(randomNeighbor.id());
+                cy.add({ group: 'edges', data: { id: `${edgeId}-${i}`, source: id, target: randomNeighbor.id()}})
               }
-                     
-              var newEdgeId = newNodesForSelected[index1].id() + "_" + newNodesForSelected[index2].id();             
-              if(!newEdgeIds.has(newEdgeId)) {
-                cy.add([
-                  { group: 'edges', data: { id: newEdgeId, source: newNodesForSelected[index1].id(), target: newNodesForSelected[index2].id() } }
-                ]);
-                newEdgeIds.add(newEdgeId);
-              }              
+            } else if (randomValue < 8) {
+              const availableCount = Math.min(neighborCount, availableCurrentNodes.length);
+              for (let i = 0; i < availableCount; i++) {
+                let randomNeighbor;
+                do {
+                  randomNeighbor = availableCurrentNodes[Math.floor(Math.random() * availableCurrentNodes.length)];
+                } while (selectedNeighbors.includes(randomNeighbor.id()));
+                selectedNeighbors.push(randomNeighbor.id());
+                cy.add({ group: 'edges', data: { id: `${edgeId}-${i}`, source: id, target: randomNeighbor.id()}})
+              }
+            } else {
+              const dummyNodeCount = neighborCount - Math.min(neighborCount / 2, availableCurrentNodes.length) - availableNewNodes.length;
+              addDummyNodes(dummyNodeCount, availableCurrentNodes);
+              for (let i = 0; i < neighborCount; i++) {
+                let randomNeighbor;
+                if (i === 0) {
+                    // Select the last new node in any case, in order to increase the probability of higher rank nodes
+                    randomNeighbor = availableNewNodes[availableNewNodes.length - 1];
+                } else {
+                  do {
+                    let tempNodes;
+                    if (i < neighborCount - Math.min(neighborCount / 2, availableCurrentNodes.length)) {
+                      tempNodes = availableNewNodes;
+                    } else {
+                      tempNodes = availableCurrentNodes;
+                    }
+                    randomNeighbor = tempNodes[Math.floor(Math.random() * tempNodes.length)];
+                  } while (selectedNeighbors.includes(randomNeighbor.id()));
+                }
+                selectedNeighbors.push(randomNeighbor.id());
+                cy.add({ group: 'edges', data: { id: `${edgeId}-${i}`, source: id, target: randomNeighbor.id()}})
+              }
             }
           }
-        });
-        
-        // place all newly added nodes to appropriate positions by using extension functionality
-        api.placeNewNodes(newNodesAll);
-        
+        }
+        return newNodes;
+      };
+      
+      $("#addRandomNeighbors").click(function() {
+        window.iteration = (window.iteration || 0) + 1;
+        cy.nodes().forEach(node => node.removeScratch());
+        const nodes = getNewNodes();
+        if (!window.addedElsHistory) window.addedElsHistory = [];
+        const els = cy.collection();
+        els.merge(nodes);
+        els.merge(nodes.connectedEdges());
+        window.addedElsHistory.unshift(els);
+        window.removedElsHistory = [];
+        api.placeNewNodes(nodes);
         if (document.getElementById('layout').checked) {
           cy.layout(layoutOptions).run();
         }
-      });      
+      });
 
       document.getElementById('load-button')
         .addEventListener('click', () =>{
@@ -511,13 +626,15 @@
 
 
     <button id="hide" class="button">Hide selected</button>
-    <br /> <br />
     <button id="showAll" class="button">Show all</button>
+    <br /> <br />
+    <button id="recalculateLayout" class="button">Recalculate Layout</button>
+    <button id="performLayout" class="button">Perform Layout</button>
     <br /> <br />
     <button id="showHiddenNeighbors" class="button">Show hidden neighbors of selected</button>
     <br /> <br />
     <button id="addRandomNeighbors" class="button">Add random neighbors to selected</button>
-    <br /> <br />    
+    <br /> <br />      
 
     <form>
       <p style="position: relative;">
@@ -526,9 +643,61 @@
         </label>
         <input type="checkbox" class="input" id="layout" name="layout" style="vertical-align:middle;" value="checked" checked>
       </p>
+      <p>
+        <label for="siblingWeight">Sibling Weight</label>
+        <input id="siblingWeight" style="width:60px; margin-bottom: 10px!important;" type="number" step="0.25"
+          min=".25" value="0.7">
+      </p>
+      <p>
+        <label for="initialNodeCount">Initial Node Count</label>
+        <input id="initialNodeCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="5"
+          min="5" value="10">
+      </p>
+      <p>
+        <label for="averageDegree">Average Degree</label>
+        <input id="averageDegree" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
+          min="0" max="10" value="2">
+      </p>
+      <p>
+        <label for="compoundNodeRatio">Compound Node Ratio</label>
+        <input id="compoundNodeRatio" style="width:60px; margin-bottom: 10px!important;" type="number" step="0.1"
+          min="0" max="0.5" value="0.1">
+      </p>
+      <p>
+        <label for="averageChildrenCount">Average Children Count</label>
+        <input id="averageChildrenCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
+          min="0" max="10" value="2">
+      </p>
+      <br/>
+      <p>
+        <label for="newNodeCount">New Node Count</label>
+        <input id="newNodeCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
+          min="0" max="10" value="2">
+      </p>
     </form>
 
 
+    <div style="display: flex;">
+      <span style="background-color: #8FE388; width: 16px; height: 16px; margin-right: 10px;"></span>
+      <span>Rank 0</span>
+    </div>
+    <div style="display: flex;">
+      <span style="background-color: #D36135; width: 16px; height: 16px; margin-right: 10px;"></span>
+      <span>Rank 1</span>
+    </div>
+    <div style="display: flex;">
+      <span style="background-color: #279AF1; width: 16px; height: 16px; margin-right: 10px;"></span>
+      <span>Rank 2</span>
+    </div>
+    <div style="display: flex;">
+      <span style="background-color: #89043D; width: 16px; height: 16px; margin-right: 10px;"></span>
+      <span>Rank 3</span>
+    </div>
+    <div style="display: flex;">
+      <span style="background-color: #000000; width: 16px; height: 16px; margin-right: 10px;"></span>
+      <span>Higher Ranks</span>
+    </div>
+  </div>
   </div>
   <div class="topnav">
 

--- a/newHeuristicDemo.html
+++ b/newHeuristicDemo.html
@@ -165,8 +165,10 @@
             style: {
               'content': 'data(name)',
               'border-color': function(ele) {
-                const { rank } = ele.scratch('layout_utilities') || {};
+                const { rank = -1 } = ele.scratch('layout_utilities') || {};
                 switch (rank) {
+                  case -1:
+                    return 'grey';
                   case 0:
                     return '#8FE388';
                   case 1:
@@ -176,7 +178,7 @@
                   case 3:
                     return '#89043D';
                   default:
-                    return 'grey';
+                    return 'black';
                 }
               },
               'border-width': 3,
@@ -347,7 +349,7 @@
 
           let neighborCount;
           let selectedNodes = cy.nodes(":selected");
-          switch (Math.ceil(Math.random() * 3)) {
+          switch (Math.ceil(Math.random() * 6)) {
             case 1:
               if (selectedNodes.length === 0) {
                 neighborCount = 0;
@@ -356,10 +358,8 @@
             case 2:
               neighborCount = 1;
               break;
-            case 3:
-              neighborCount = averageDegree;
-              break;
             default:
+              neighborCount = averageDegree;
               break;
           }
 
@@ -383,57 +383,56 @@
             const availableNewNodes = newNodes.difference(forbiddenNodes)
             const availableCurrentNodes = selectedNodes.length > 0 ? selectedNodes : currentNodes.difference(forbiddenNodes)
             const selectedNeighbors = [];
-            switch (Math.ceil(Math.random() * 5)) {
-              case 1:
-              case 2: { // All new neighbors
-                if (selectedNodes.length === 0) {
-                  const dummyNodeCount = neighborCount - availableNewNodes.length;
-                  addDummyNodes(dummyNodeCount, availableCurrentNodes);
-                  for (let i = 0; i < neighborCount; i++) {
-                    let randomNeighbor;
-                    do {
-                      randomNeighbor = availableNewNodes[Math.floor(Math.random() * availableNewNodes.length)];
-                    } while (selectedNeighbors.includes(randomNeighbor.id()));
-                    selectedNeighbors.push(randomNeighbor.id());
-                    cy.add({ group: 'edges', data: { id: `${edgeId}-${i}`, source: id, target: randomNeighbor.id()}})
-                  }
-                  break;
-                }
-              }
-              case 3: { // All existing neighbors
-                const availableCount = Math.min(neighborCount, availableCurrentNodes.length);
-                for (let i = 0; i < availableCount; i++) {
-                  let randomNeighbor;
+
+            const randomValue = Math.ceil(Math.random() * 10);
+            if (randomValue < 6 && selectedNodes.length === 0) {
+              const dummyNodeCount = neighborCount - availableNewNodes.length;
+              addDummyNodes(dummyNodeCount, availableCurrentNodes);
+              for (let i = 0; i < neighborCount; i++) {
+                let randomNeighbor;
+                if (i === 0) {
+                  // Select the last new node in any case, in order to increase the probability of higher rank nodes
+                  randomNeighbor = availableNewNodes[availableNewNodes.length - 1];
+                } else {
                   do {
-                    randomNeighbor = availableCurrentNodes[Math.floor(Math.random() * availableCurrentNodes.length)];
+                    randomNeighbor = availableNewNodes[Math.floor(Math.random() * availableNewNodes.length)];
                   } while (selectedNeighbors.includes(randomNeighbor.id()));
-                  selectedNeighbors.push(randomNeighbor.id());
-                  cy.add({ group: 'edges', data: { id: `${edgeId}-${i}`, source: id, target: randomNeighbor.id()}})
                 }
-                break;
+                selectedNeighbors.push(randomNeighbor.id());
+                cy.add({ group: 'edges', data: { id: `${edgeId}-${i}`, source: id, target: randomNeighbor.id()}})
               }
-              case 4:
-              case 5: { // Both
-                const dummyNodeCount = neighborCount / 2 - availableNewNodes.length;
-                addDummyNodes(dummyNodeCount, availableCurrentNodes);
-                for (let i = 0; i < neighborCount; i++) {
-                  let randomNeighbor;
+            } else if (randomValue < 8) {
+              const availableCount = Math.min(neighborCount, availableCurrentNodes.length);
+              for (let i = 0; i < availableCount; i++) {
+                let randomNeighbor;
+                do {
+                  randomNeighbor = availableCurrentNodes[Math.floor(Math.random() * availableCurrentNodes.length)];
+                } while (selectedNeighbors.includes(randomNeighbor.id()));
+                selectedNeighbors.push(randomNeighbor.id());
+                cy.add({ group: 'edges', data: { id: `${edgeId}-${i}`, source: id, target: randomNeighbor.id()}})
+              }
+            } else {
+              const dummyNodeCount = neighborCount / 2 - availableNewNodes.length;
+              addDummyNodes(dummyNodeCount, availableCurrentNodes);
+              for (let i = 0; i < neighborCount; i++) {
+                let randomNeighbor;
+                if (i === 0) {
+                    // Select the last new node in any case, in order to increase the probability of higher rank nodes
+                    randomNeighbor = availableNewNodes[availableNewNodes.length - 1];
+                } else {
                   do {
                     let tempNodes;
                     if (i < Math.min(neighborCount / 2, availableCurrentNodes.length)) {
-                      tempNodes = availableCurrentNodes;
-                    } else {
                       tempNodes = availableNewNodes;
+                    } else {
+                      tempNodes = availableCurrentNodes;
                     }
                     randomNeighbor = tempNodes[Math.floor(Math.random() * tempNodes.length)];
                   } while (selectedNeighbors.includes(randomNeighbor.id()));
-                  selectedNeighbors.push(randomNeighbor.id());
-                  cy.add({ group: 'edges', data: { id: `${edgeId}-${i}`, source: id, target: randomNeighbor.id()}})
                 }
-                break;
+                selectedNeighbors.push(randomNeighbor.id());
+                cy.add({ group: 'edges', data: { id: `${edgeId}-${i}`, source: id, target: randomNeighbor.id()}})
               }
-              default:
-                break;
             }
           }
         }
@@ -565,6 +564,10 @@
         <div style="display: flex;">
           <span style="background-color: #89043D; width: 16px; height: 16px; margin-right: 10px;"></span>
           <span>Rank 3</span>
+        </div>
+        <div style="display: flex;">
+          <span style="background-color: #000000; width: 16px; height: 16px; margin-right: 10px;"></span>
+          <span>Higher Ranks</span>
         </div>
         <br/>
         <div>

--- a/newHeuristicDemo.html
+++ b/newHeuristicDemo.html
@@ -322,9 +322,9 @@
         const currentNodes = cy.nodes();
         const compoundNodes = cy.nodes().filter(e => e.isParent());
         let newCompound;
-        for (let i = 0; i < nodeCount; i++) {
-          const id = `n${window.iteration}-${i}`;
-          const edgeId = `e${window.iteration}-${i}`;
+        for (let nodeId = 0; nodeId < nodeCount; nodeId++) {
+          const id = `n${window.iteration}-${nodeId}`;
+          const edgeId = `e${window.iteration}-${nodeId}`;
           let parentID;
           switch (Math.ceil(Math.random() * 3)) {
             case 1: // New parent
@@ -412,7 +412,7 @@
                 cy.add({ group: 'edges', data: { id: `${edgeId}-${i}`, source: id, target: randomNeighbor.id()}})
               }
             } else {
-              const dummyNodeCount = neighborCount / 2 - availableNewNodes.length;
+              const dummyNodeCount = neighborCount - Math.min(neighborCount / 2, availableCurrentNodes.length) - availableNewNodes.length;
               addDummyNodes(dummyNodeCount, availableCurrentNodes);
               for (let i = 0; i < neighborCount; i++) {
                 let randomNeighbor;
@@ -422,7 +422,7 @@
                 } else {
                   do {
                     let tempNodes;
-                    if (i < Math.min(neighborCount / 2, availableCurrentNodes.length)) {
+                    if (i < neighborCount - Math.min(neighborCount / 2, availableCurrentNodes.length)) {
                       tempNodes = availableNewNodes;
                     } else {
                       tempNodes = availableCurrentNodes;
@@ -449,7 +449,7 @@
         els.merge(nodes.connectedEdges());
         window.addedElsHistory.unshift(els);
         window.removedElsHistory = [];
-        api.placeNewNodesNewHeuristic(nodes);
+        api.placeNewNodes(nodes);
         if (document.getElementById('layout').checked) {
           cy.layout(layoutOptions).run();
         }
@@ -459,8 +459,12 @@
         api.setOption("siblingWeight", parseFloat(e.target.value));
       });
 
-      $('#rearrange').click(function() {
+      $('#recalculateLayout').click(function() {
         cy.layout(layoutOptions).run();
+      })
+
+      $('#performLayout').click(function() {
+        cy.layout({...layoutOptions, randomize: true}).run();
       })
 
       $("#undo").click(function() {
@@ -483,7 +487,7 @@
           if (!window.addedElsHistory) window.addedElsHistory = [];
           window.addedElsHistory.unshift(els);
           cy.add(els);
-          api.placeNewNodesNewHeuristic(els.nodes());
+          api.placeNewNodes(els.nodes());
           if (document.getElementById('layout').checked) {
             cy.layout(layoutOptions).run();
           }
@@ -505,7 +509,8 @@
         <br /> <br />
         <button id="newHeuristic" class="button">New Heuristic</button>
         <br /> <br />   
-        <button id="rearrange" class="button">Rearrange</button>
+        <button id="recalculateLayout" class="button">Recalculate Layout</button>
+        <button id="performLayout" class="button">Perform Layout</button>
         <br /> <br />              
         <button id="undo" class="button">Undo</button>
         <button id="redo" class="button">Redo</button>

--- a/newHeuristicDemo.html
+++ b/newHeuristicDemo.html
@@ -24,6 +24,10 @@
       font-size: 14px;
     }
 
+    .container {
+      display: flex;
+    }
+
     .button {
       height: 35px;
       font-size: 16;
@@ -66,18 +70,13 @@
     }
 
     #cy {
-      width: 80%;
-      height: 95%;
-      left: 21%;
-      top: 0%;
-      float: left;
+      flex: 0.8;
       overflow: hidden;
-      position: fixed;
 
     }
 
     .topnav {
-      width: 20%;
+      flex: 0.2;
       background-color: #e9e9e9;
       /* font-weight: bold;*/
       border-color: black;
@@ -228,13 +227,6 @@
               'border-width': '5px'
             }
           },
-          {
-            selector: 'node[existing]',
-            style: {
-              'border-color': '#6E44FF',
-              'border-width': '5px'
-            }
-          },
         ],
 
         elements: {
@@ -259,6 +251,7 @@
         randomize: false,
         fit: false,
         packComponents: false,
+        nodeDimensionsIncludeLabels: true
       };
 
       cy.layout(layoutOptions).run();
@@ -371,10 +364,13 @@
           newNodes.merge(newNode);
 
           let neighborCount;
+          let selectedNodes = cy.nodes(":selected");
           switch (Math.ceil(Math.random() * 3)) {
             case 1:
-              neighborCount = 0;
-              break;
+              if (selectedNodes.length === 0) {
+                neighborCount = 0;
+                break;
+              }
             case 2:
               neighborCount = 1;
               break;
@@ -391,30 +387,33 @@
             forbiddenNodes.merge(newNode.ancestors());
             forbiddenNodes.merge(newNode.descendants());
             const availableNewNodes = newNodes.difference(forbiddenNodes)
-            const availableCurrentNodes = currentNodes.difference(forbiddenNodes)
+            const availableCurrentNodes = selectedNodes.length > 0 ? selectedNodes : currentNodes.difference(forbiddenNodes)
             const selectedNeighbors = [];
             switch (Math.ceil(Math.random() * 3)) {
               case 1: { // All new neighbors
-                const dummyNodeCount = neighborCount - availableNewNodes.length;
-                for (let i = 0; i < dummyNodeCount; i++) {
-                  // Add necessary dummy nodes
-                  const dummyID = `${id}-d${i}`;
-                  const dummyNode = cy.add({ group: 'nodes', data: { id: dummyID, name: dummyID}});
-                  newNodes.merge(dummyNode)
-                  availableNewNodes.merge(dummyNode)
+                if (selectedNodes.length === 0) {
+                  const dummyNodeCount = neighborCount - availableNewNodes.length;
+                  for (let i = 0; i < dummyNodeCount; i++) {
+                    // Add necessary dummy nodes
+                    const dummyID = `${id}-d${i}`;
+                    const dummyNode = cy.add({ group: 'nodes', data: { id: dummyID, name: dummyID}});
+                    newNodes.merge(dummyNode)
+                    availableNewNodes.merge(dummyNode)
+                  }
+                  for (let i = 0; i < neighborCount; i++) {
+                    let randomNeighbor;
+                    do {
+                      randomNeighbor = availableNewNodes[Math.floor(Math.random() * availableNewNodes.length)];
+                    } while (selectedNeighbors.includes(randomNeighbor.id()));
+                    selectedNeighbors.push(randomNeighbor.id());
+                    cy.add({ group: 'edges', data: { id: `${edgeId}-${i}`, source: id, target: randomNeighbor.id()}})
+                  }
+                  break;
                 }
-                for (let i = 0; i < neighborCount; i++) {
-                  let randomNeighbor;
-                  do {
-                    randomNeighbor = availableNewNodes[Math.floor(Math.random() * availableNewNodes.length)];
-                  } while (selectedNeighbors.includes(randomNeighbor.id()));
-                  selectedNeighbors.push(randomNeighbor.id());
-                  cy.add({ group: 'edges', data: { id: `${edgeId}-${i}`, source: id, target: randomNeighbor.id()}})
-                }
-                break;
               }
               case 2: { // All existing neighbors
-                for (let i = 0; i < neighborCount; i++) {
+                const availableCount = Math.min(neighborCount, availableCurrentNodes.length);
+                for (let i = 0; i < availableCount; i++) {
                   let randomNeighbor;
                   do {
                     randomNeighbor = availableCurrentNodes[Math.floor(Math.random() * availableCurrentNodes.length)];
@@ -437,10 +436,10 @@
                   let randomNeighbor;
                   do {
                     let tempNodes;
-                    if (i < neighborCount / 2) {
-                      tempNodes = availableNewNodes;
-                    } else {
+                    if (i < Math.min(neighborCount / 2, availableCurrentNodes.length)) {
                       tempNodes = availableCurrentNodes;
+                    } else {
+                      tempNodes = availableNewNodes;
                     }
                     randomNeighbor = tempNodes[Math.floor(Math.random() * tempNodes.length)];
                   } while (selectedNeighbors.includes(randomNeighbor.id()));
@@ -477,6 +476,10 @@
       document.getElementById('siblingWeight').addEventListener('change', function(e) {
         api.setOption("siblingWeight", parseFloat(e.target.value));
       });
+
+      $('#rearrange').click(function() {
+        cy.layout(layoutOptions).run();
+      })
 
       $("#undo").click(function() {
         const els = window.addedElsHistory.shift();
@@ -515,87 +518,81 @@
 
 <body>
   <h1>New Heuristic Random Demo</h1>
-  <div class="topnav">
-    <button id="reset" class="button">Restart</button>
-    <br /> <br />
-    <button id="newHeuristic" class="button">New Heuristic</button>
-    <br /> <br />                
-    <button id="undo" class="button">Undo</button>
-    <button id="redo" class="button">Redo</button>
-
-    <form>
-      <p style="position: relative;">
-        <label for="layout" style="vertical-align:middle;">
-          Rearrange on changes
-        </label>
-        <input type="checkbox" class="input" id="layout" name="layout" style="vertical-align:middle; margin-bottom: 10px;">
-      </p>
-      <p>
-        <label for="siblingWeight">Sibling Weight</label>
-        <input id="siblingWeight" style="width:60px; margin-bottom: 10px!important;" type="number" step="0.25"
-          min=".25" value="0.7">
-      </p>
-      <p>
-        <label for="initialNodeCount">Initial Node Count</label>
-        <input id="initialNodeCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="5"
-          min="5" value="10">
-      </p>
-      <p>
-        <label for="averageDegree">Average Degree</label>
-        <input id="averageDegree" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
-          min="0" max="10" value="2">
-      </p>
-      <p>
-        <label for="compoundNodeRatio">Compound Node Ratio</label>
-        <input id="compoundNodeRatio" style="width:60px; margin-bottom: 10px!important;" type="number" step="0.1"
-          min="0" max="0.5" value="0.1">
-      </p>
-      <p>
-        <label for="averageChildrenCount">Average Children Count</label>
-        <input id="averageChildrenCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
-          min="0" max="10" value="2">
-      </p>
+  <div class='container'>
+    <div class="topnav">
+      <button id="reset" class="button">Restart</button>
+      <br /> <br />
+      <button id="newHeuristic" class="button">New Heuristic</button>
+      <br /> <br />   
+      <button id="rearrange" class="button">Rearrange</button>
+      <br /> <br />              
+      <button id="undo" class="button">Undo</button>
+      <button id="redo" class="button">Redo</button>
+      <br /> <br />
+      <form>
+        <p>
+          <label for="siblingWeight">Sibling Weight</label>
+          <input id="siblingWeight" style="width:60px; margin-bottom: 10px!important;" type="number" step="0.25"
+            min=".25" value="0.7">
+        </p>
+        <p>
+          <label for="initialNodeCount">Initial Node Count</label>
+          <input id="initialNodeCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="5"
+            min="5" value="10">
+        </p>
+        <p>
+          <label for="averageDegree">Average Degree</label>
+          <input id="averageDegree" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
+            min="0" max="10" value="2">
+        </p>
+        <p>
+          <label for="compoundNodeRatio">Compound Node Ratio</label>
+          <input id="compoundNodeRatio" style="width:60px; margin-bottom: 10px!important;" type="number" step="0.1"
+            min="0" max="0.5" value="0.1">
+        </p>
+        <p>
+          <label for="averageChildrenCount">Average Children Count</label>
+          <input id="averageChildrenCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
+            min="0" max="10" value="2">
+        </p>
+        <br/>
+        <p>
+          <label for="newNodeCount">New Node Count</label>
+          <input id="newNodeCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
+            min="0" max="10" value="2">
+        </p>
+      </form>
+      <div style="display: flex;">
+        <span style="background-color: #8FE388; width: 16px; height: 16px; margin-right: 10px;"></span>
+        <span>Rank 0</span>
+      </div>
+      <div style="display: flex;">
+        <span style="background-color: #D36135; width: 16px; height: 16px; margin-right: 10px;"></span>
+        <span>Rank 1</span>
+      </div>
+      <div style="display: flex;">
+        <span style="background-color: #279AF1; width: 16px; height: 16px; margin-right: 10px;"></span>
+        <span>Rank 2</span>
+      </div>
+      <div style="display: flex;">
+        <span style="background-color: #89043D; width: 16px; height: 16px; margin-right: 10px;"></span>
+        <span>Rank 3</span>
+      </div>
       <br/>
-      <p>
-        <label for="newNodeCount">New Node Count</label>
-        <input id="newNodeCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
-          min="0" max="10" value="2">
-      </p>
-    </form>
-    <div style="display: flex;">
-      <span style="background-color: #8FE388; width: 16px; height: 16px; margin-right: 10px;"></span>
-      <span>Rank 0</span>
+      <div>
+        Node name convention: <b>{a}{b}-{c}[-{d}]</b>
+        <br/>
+        <b>a:</b> "n" for new nodes, "c" for initial nodes
+        <br/>
+        <b>b:</b> # of iteration where this node is placed
+        <br/>
+        <b>c:</b> # of node in the iteration
+        <br/>
+        <b>d:</b> (Optional) indicates auxiliary node
+      </div>
     </div>
-    <div style="display: flex;">
-      <span style="background-color: #D36135; width: 16px; height: 16px; margin-right: 10px;"></span>
-      <span>Rank 1</span>
-    </div>
-    <div style="display: flex;">
-      <span style="background-color: #279AF1; width: 16px; height: 16px; margin-right: 10px;"></span>
-      <span>Rank 2</span>
-    </div>
-    <div style="display: flex;">
-      <span style="background-color: #89043D; width: 16px; height: 16px; margin-right: 10px;"></span>
-      <span>Rank 3</span>
-    </div>
-    <div style="display: flex;">
-      <span style="background-color: #6E44FF; width: 16px; height: 16px; margin-right: 10px;"></span>
-      <span>Existing Node</span>
-    </div>
-    <br/>
-    <div>
-      Node name convention: <b>{a}{b}-{c}[-{d}]</b>
-      <br/>
-      <b>a:</b> "n" for new nodes, "c" for initial nodes
-      <br/>
-      <b>b:</b> # of iteration where this node is placed
-      <br/>
-      <b>c:</b> # of node in the iteration
-      <br/>
-      <b>d:</b> (Optional) indicates auxiliary node
-    </div>
+    <div id="cy"></div>
   </div>
-  <div id="cy"></div>
 
 </body>
 

--- a/newHeuristicDemo.html
+++ b/newHeuristicDemo.html
@@ -164,7 +164,21 @@
             selector: 'node',
             style: {
               'content': 'data(name)',
-              'border-color': 'grey',
+              'border-color': function(ele) {
+                const { rank } = ele.scratch('layout_utilities') || {};
+                switch (rank) {
+                  case 0:
+                    return '#8FE388';
+                  case 1:
+                    return '#D36135';
+                  case 2:
+                    return '#279AF1';
+                  case 3:
+                    return '#89043D';
+                  default:
+                    return 'grey';
+                }
+              },
               'border-width': 3,
               'background-color': 'lightgrey'
             }
@@ -185,34 +199,6 @@
             selector: 'node:parent',
             style: {
               'background-color': 'lightgrey'
-            }
-          },
-          {
-            selector: 'node[rank=0]',
-            style: {
-              'border-color': '#8FE388',
-              'border-width': '5px'
-            }
-          },
-          {
-            selector: 'node[rank=1]',
-            style: {
-              'border-color': '#D36135',
-              'border-width': '5px'
-            }
-          },
-          {
-            selector: 'node[rank=2]',
-            style: {
-              'border-color': '#279AF1',
-              'border-width': '5px'
-            }
-          },
-          {
-            selector: 'node[rank=3]',
-            style: {
-              'border-color': '#89043D',
-              'border-width': '5px'
             }
           },
           {
@@ -263,7 +249,7 @@
         });
         return eles;
       }
-
+    
       function generateRandomNodes() {
         const nodeCount = parseInt($('#initialNodeCount').val());
         const compoundNodeRatio = parseFloat($('#compoundNodeRatio').val());
@@ -275,7 +261,7 @@
         for (let i = 0; i < nodeCount; i++) {
           nodes.push({
             group: 'nodes',
-            data: { id: `c${i}`, name: `c${i}`, existing: true },
+            data: { id: `c${i}`, name: `c${i}`},
             position: {
               x: Math.floor(Math.random() * offset) - offset / 2,
               y: Math.floor(Math.random() * offset) - offset / 2,
@@ -456,8 +442,7 @@
 
       $("#newHeuristic").click(function() {
         window.iteration = (window.iteration || 0) + 1;
-        cy.nodes().removeData('calculated rank escalatedNeighbors');
-        cy.nodes().data('existing', true)
+        cy.nodes().forEach(node => node.removeScratch());
         const nodes = getNewNodes();
         if (!window.addedElsHistory) window.addedElsHistory = [];
         const els = cy.collection();
@@ -492,11 +477,10 @@
       });
 
       $("#redo").click(function() {
-        cy.nodes().removeData('calculated rank escalatedNeighbors');
-        cy.nodes().data('existing', true);
+        cy.nodes().forEach(node => node.removeScratch());
         const els = window.removedElsHistory.shift();
         if (els) {
-          els.nodes().removeData('calculated rank existing escalatedNeighbors');
+          els.nodes().forEach(node => node.removeScratch());
           if (!window.addedElsHistory) window.addedElsHistory = [];
           window.addedElsHistory.unshift(els);
           cy.add(els);

--- a/newHeuristicDemo.html
+++ b/newHeuristicDemo.html
@@ -507,6 +507,9 @@
       });
     });
 
+    setTimeout(() => {
+      $("#reset").click();
+    }, 0)
   </script>
 </head>
 

--- a/newHeuristicDemo.html
+++ b/newHeuristicDemo.html
@@ -1,0 +1,599 @@
+<!DOCTYPE>
+<html>
+
+<head>
+  <title>cytoscape-layout-utilities.js demo</title>
+
+  <!--- <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1"> -->
+
+  <script src="https://code.jquery.com/jquery-3.0.0.min.js"></script>
+  <script src="https://unpkg.com/cytoscape/dist/cytoscape.min.js"></script>
+
+  <!-- for testing with local version of cytoscape.js -->
+  <!--<script src="../cytoscape.js/build/cytoscape.js"></script>-->
+  <script src="https://raw.githack.com/iVis-at-Bilkent/layout-base/unstable/layout-base.js"></script>
+  <script src="https://raw.githack.com/iVis-at-Bilkent/cose-base/unstable/cose-base.js"></script>
+  <script src="https://raw.githack.com/iVis-at-Bilkent/cytoscape.js-fcose/unstable/cytoscape-fcose.js"></script>
+  <script src="https://unpkg.com/cytoscape-graphml/cytoscape-graphml.js"></script>
+  <script src="cytoscape-layout-utilities.js"></script>
+
+  <script src="https://unpkg.com/cytoscape-view-utilities/cytoscape-view-utilities.js"></script>
+  <style>
+    body {
+      font-family: helvetica neue, helvetica, liberation sans, arial, sans-serif;
+      font-size: 14px;
+    }
+
+    .button {
+      height: 35px;
+      font-size: 16;
+      color: brown;
+      font-weight: bold;
+      cursor: pointer;
+    }
+
+    input[type="file"] {
+      display: none;
+    }
+
+    .custom-file-upload {
+      border: 1px solid #ccc;
+      display: inline-block;
+      padding: 6px 12px;
+      cursor: pointer;
+    } 
+
+    form {
+      display: table;
+    }
+
+    p {
+      display: table-row;
+    }
+
+    label {
+      display: table-cell;
+      font-size: 14;
+    }
+
+    select {
+      display: table-cell;
+    }
+
+    input {
+      display: table-cell;
+      margin-left: 5px;
+    }
+
+    #cy {
+      width: 80%;
+      height: 95%;
+      left: 21%;
+      top: 0%;
+      float: left;
+      overflow: hidden;
+      position: fixed;
+
+    }
+
+    .topnav {
+      width: 20%;
+      background-color: #e9e9e9;
+      /* font-weight: bold;*/
+      border-color: black;
+      border-style: solid;
+      font-size: 16;
+      padding: 10;
+    }
+
+    .topnav b:hover {
+      background-color: white;
+    }
+
+    /* Customize the label (the container) */
+    .topnav .container {
+
+      position: relative;
+      padding: 14px;
+      cursor: pointer;
+      font-size: 15px;
+      left: 5px;
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+    }
+
+    /* Hide the browser's default radio button */
+    .topnav .container input {
+      position: absolute;
+      opacity: 0;
+      cursor: pointer;
+      height: 0;
+      width: 0;
+    }
+
+    /* Create a custom radio button */
+    .topnav .checkmark {
+      position: absolute;
+      top: 17px;
+      left: 0;
+      right: 0px;
+      height: 12px;
+      width: 12px;
+      margin-right: 20px;
+      background-color: #000000;
+      border-radius: 50%;
+    }
+
+    /* On mouse-over, add a grey background color */
+    .container:hover input~.checkmark {
+      background-color: #000000;
+    }
+
+    /* When the radio button is checked, add a blue background */
+    .container input:checked~.checkmark {
+      background-color: #000
+    }
+
+    /* Create the indicator (the dot/circle - hidden when not checked) */
+    .checkmark:after {
+      content: "";
+      position: absolute;
+      display: none;
+    }
+
+    /* Show the indicator (dot/circle) when checked */
+    .container input:checked~.checkmark:after {
+      display: block;
+    }
+
+    /* Style the indicator (dot/circle) */
+    .container .checkmark:after {
+      position: absolute;
+      top: 3px;
+      left: 3px;
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: white;
+    }
+  </style>
+  <script>
+    document.addEventListener("DOMContentLoaded", function () {
+      var cy = window.cy = cytoscape({
+        container: document.getElementById('cy'),
+        layout: { name: "fcose" },
+        style: [
+          {
+            selector: 'node',
+            style: {
+              'content': 'data(name)',
+              'border-color': 'grey',
+              'border-width': 3,
+              'background-color': 'lightgrey'
+            }
+          },
+          {
+            selector: 'edge',
+            style: {
+              'target-arrow-shape': 'triangle'
+            }
+          },
+          {
+            selector: 'edge:selected',
+            style: {
+              'line-color': 'orange'
+            }
+          },
+          {
+            selector: 'node:selected',
+            style: {
+              'border-color': 'orange',
+              'border-width': '3px',
+              'background-color': 'lightgrey'
+            }
+          },
+          {
+            selector: 'node:parent',
+            style: {
+              'background-color': 'lightgrey'
+            }
+          },
+          {
+            selector: 'node[rank=0]',
+            style: {
+              'border-color': '#8FE388',
+              'border-width': '5px'
+            }
+          },
+          {
+            selector: 'node[rank=1]',
+            style: {
+              'border-color': '#D36135',
+              'border-width': '5px'
+            }
+          },
+          {
+            selector: 'node[rank=2]',
+            style: {
+              'border-color': '#279AF1',
+              'border-width': '5px'
+            }
+          },
+          {
+            selector: 'node[rank=3]',
+            style: {
+              'border-color': '#89043D',
+              'border-width': '5px'
+            }
+          },
+          {
+            selector: 'node[existing]',
+            style: {
+              'border-color': '#6E44FF',
+              'border-width': '5px'
+            }
+          },
+        ],
+
+        elements: {
+          nodes: []
+        },
+        wheelSensitivity: 0.2
+      });
+
+      var api = cy.layoutUtilities(
+        {
+          desiredAspectRatio: 1,
+          polyominoGridSizeFactor: 1,
+          utilityFunction: 1,
+          componentSpacing: 80,
+          siblingWeight: parseFloat($('#siblingWeight').val())
+        }
+      );
+      var api2 = cy.viewUtilities();
+
+      var layoutOptions = {
+        name: 'fcose',
+        randomize: false,
+        fit: false,
+        packComponents: false,
+      };
+
+      cy.layout(layoutOptions).run();
+      function changeBorder(eles) {
+        eles.forEach(function (ele) {
+          ele.css("background-color", 'purple');
+        });
+        return eles;
+      }
+      function revertBorder(eles) {
+        eles.forEach(function (ele) {
+          ele.css("background-color", 'lightgrey');
+        });
+        return eles;
+      }
+
+      function generateRandomNodes() {
+        const nodeCount = parseInt($('#initialNodeCount').val());
+        const compoundNodeRatio = parseFloat($('#compoundNodeRatio').val());
+        const averageDegree = parseInt($('#averageDegree').val());
+        const averageChildrenCount = parseInt($('#averageChildrenCount').val());
+        const offset = 50;
+
+        const nodes = [];
+        for (let i = 0; i < nodeCount; i++) {
+          nodes.push({
+            group: 'nodes',
+            data: { id: `c${i}`, name: `c${i}`, existing: true },
+            position: {
+              x: Math.floor(Math.random() * offset) - offset / 2,
+              y: Math.floor(Math.random() * offset) - offset / 2,
+            }
+          })
+        }
+        let compoundNodeCount = nodeCount * compoundNodeRatio;
+        let totalChildrenCount = compoundNodeCount * averageChildrenCount;
+        if (totalChildrenCount + compoundNodeCount >= nodeCount) {
+          return [];
+        }
+        for (let i = 0; i < compoundNodeCount; i++) {
+          const randomIndex = Math.floor(Math.random() * nodeCount);
+          let childrenCount = Math.ceil(Math.random() * 2 * (totalChildrenCount / compoundNodeCount));
+          while (totalChildrenCount > 0 && (i === compoundNodeCount - 1 || childrenCount > 0)) {
+            let childIndex;
+            do {
+              childIndex = Math.floor(Math.random() * nodeCount);
+            } while (nodes[childIndex].data.parent || childIndex === randomIndex); 
+            nodes[childIndex].data.parent = `c${randomIndex}`;
+            childrenCount--;
+            totalChildrenCount--;
+          }
+        }
+
+        const edges = [];
+        let totalEdgeCount = Math.floor(averageDegree * nodeCount / 2);
+        for (let i = 0; i < totalEdgeCount; i++) {
+          const sourceIndex = Math.floor(Math.random() * nodeCount);
+          let targetIndex;
+          do {
+            targetIndex = Math.floor(Math.random() * nodeCount);
+          } while (targetIndex === sourceIndex
+                || nodes[targetIndex].data.parent === `c${sourceIndex}`
+                || nodes[sourceIndex].data.parent === `c${targetIndex}`);
+          edges.push({
+            group: 'edges',
+            data: { id: `e${i}`, name: `e${i}`, source: `c${sourceIndex}`, target: `c${targetIndex}`}
+          })
+        }
+        return [...nodes, ...edges];
+      }
+
+      $("#reset").click(function() {
+        window.iteration = 0;
+        cy.remove(cy.nodes());
+        cy.add(generateRandomNodes());
+        cy.layout(layoutOptions).run();
+        cy.center();
+      });
+
+      function getNewNodes() {
+        const nodeCount = parseInt($('#newNodeCount').val());
+        const averageDegree = parseInt($('#averageDegree').val());
+        const newNodes = cy.collection();
+        const currentNodes = cy.nodes();
+        const compoundNodes = cy.nodes().filter(e => e.isParent());
+        let newCompound;
+        for (let i = 0; i < nodeCount; i++) {
+          const id = `n${window.iteration}-${i}`;
+          const edgeId = `e${window.iteration}-${i}`;
+          let parentID;
+          switch (Math.ceil(Math.random() * 3)) {
+            case 1: // New parent
+              if (newNodes.length === 0) {
+                newNodes.merge(cy.add({group: 'nodes', data: {id: `${id}a`, name: `${id}a`}}));
+              }
+              if (!newCompound) {
+                const randomNewCompound = newNodes[Math.floor(Math.random() * newNodes.length)];
+                newCompound = randomNewCompound;
+              }
+              parentID = newCompound.id();
+              break;
+            case 2: // Existing parent
+              parentID = compoundNodes[Math.floor(Math.random() * compoundNodes.length)].id()
+              break;
+            case 3: // No parent
+            default:
+              break;
+          }
+          const newNode = cy.add({ group: 'nodes', data: { id, name: id, parent: parentID }});
+          newNodes.merge(newNode);
+
+          let neighborCount;
+          switch (Math.ceil(Math.random() * 3)) {
+            case 1:
+              neighborCount = 0;
+              break;
+            case 2:
+              neighborCount = 1;
+              break;
+            case 3:
+              neighborCount = averageDegree;
+              break;
+            default:
+              break;
+          }
+
+          if (neighborCount) {
+            const forbiddenNodes = cy.collection();
+            forbiddenNodes.merge(newNode);
+            forbiddenNodes.merge(newNode.ancestors());
+            forbiddenNodes.merge(newNode.descendants());
+            const availableNewNodes = newNodes.difference(forbiddenNodes)
+            const availableCurrentNodes = currentNodes.difference(forbiddenNodes)
+            const selectedNeighbors = [];
+            switch (Math.ceil(Math.random() * 3)) {
+              case 1: { // All new neighbors
+                const dummyNodeCount = neighborCount - availableNewNodes.length;
+                for (let i = 0; i < dummyNodeCount; i++) {
+                  // Add necessary dummy nodes
+                  const dummyID = `${id}-d${i}`;
+                  const dummyNode = cy.add({ group: 'nodes', data: { id: dummyID, name: dummyID}});
+                  newNodes.merge(dummyNode)
+                  availableNewNodes.merge(dummyNode)
+                }
+                for (let i = 0; i < neighborCount; i++) {
+                  let randomNeighbor;
+                  do {
+                    randomNeighbor = availableNewNodes[Math.floor(Math.random() * availableNewNodes.length)];
+                  } while (selectedNeighbors.includes(randomNeighbor.id()));
+                  selectedNeighbors.push(randomNeighbor.id());
+                  cy.add({ group: 'edges', data: { id: `${edgeId}-${i}`, source: id, target: randomNeighbor.id()}})
+                }
+                break;
+              }
+              case 2: { // All existing neighbors
+                for (let i = 0; i < neighborCount; i++) {
+                  let randomNeighbor;
+                  do {
+                    randomNeighbor = availableCurrentNodes[Math.floor(Math.random() * availableCurrentNodes.length)];
+                  } while (selectedNeighbors.includes(randomNeighbor.id()));
+                  selectedNeighbors.push(randomNeighbor.id());
+                  cy.add({ group: 'edges', data: { id: `${edgeId}-${i}`, source: id, target: randomNeighbor.id()}})
+                }
+                break;
+              }
+              case 3: { // Both
+                const dummyNodeCount = neighborCount / 2 - availableNewNodes.length;
+                for (let i = 0; i < dummyNodeCount; i++) {
+                  // Add necessary dummy nodes
+                  const dummyID = `${id}-d${i}`;
+                  const dummyNode = cy.add({ group: 'nodes', data: { id: dummyID, name: dummyID}});
+                  newNodes.merge(dummyNode)
+                  availableNewNodes.merge(dummyNode)
+                }
+                for (let i = 0; i < neighborCount; i++) {
+                  let randomNeighbor;
+                  do {
+                    let tempNodes;
+                    if (i < neighborCount / 2) {
+                      tempNodes = availableNewNodes;
+                    } else {
+                      tempNodes = availableCurrentNodes;
+                    }
+                    randomNeighbor = tempNodes[Math.floor(Math.random() * tempNodes.length)];
+                  } while (selectedNeighbors.includes(randomNeighbor.id()));
+                  selectedNeighbors.push(randomNeighbor.id());
+                  cy.add({ group: 'edges', data: { id: `${edgeId}-${i}`, source: id, target: randomNeighbor.id()}})
+                }
+                break;
+              }
+              default:
+                break;
+            }
+          }
+        }
+        return newNodes;
+      };
+
+      $("#newHeuristic").click(function() {
+        window.iteration = (window.iteration || 0) + 1;
+        cy.nodes().removeData('calculated rank escalatedNeighbors');
+        cy.nodes().data('existing', true)
+        const nodes = getNewNodes();
+        if (!window.addedElsHistory) window.addedElsHistory = [];
+        const els = cy.collection();
+        els.merge(nodes);
+        els.merge(nodes.connectedEdges());
+        window.addedElsHistory.unshift(els);
+        window.removedElsHistory = [];
+        api.placeNewNodesNewHeuristic(nodes);
+        if (document.getElementById('layout').checked) {
+          cy.layout(layoutOptions).run();
+        }
+      });
+
+      document.getElementById('siblingWeight').addEventListener('change', function(e) {
+        api.setOption("siblingWeight", parseFloat(e.target.value));
+      });
+
+      $("#undo").click(function() {
+        const els = window.addedElsHistory.shift();
+        if (els) {
+          if (!window.removedElsHistory) window.removedElsHistory = [];
+          cy.remove(els);
+          window.removedElsHistory.unshift(els);
+          if (document.getElementById('layout').checked) {
+            cy.layout(layoutOptions).run();
+          }
+        }
+      });
+
+      $("#redo").click(function() {
+        cy.nodes().removeData('calculated rank escalatedNeighbors');
+        cy.nodes().data('existing', true);
+        const els = window.removedElsHistory.shift();
+        if (els) {
+          els.nodes().removeData('calculated rank existing escalatedNeighbors');
+          if (!window.addedElsHistory) window.addedElsHistory = [];
+          window.addedElsHistory.unshift(els);
+          cy.add(els);
+          api.placeNewNodesNewHeuristic(els.nodes());
+          if (document.getElementById('layout').checked) {
+            cy.layout(layoutOptions).run();
+          }
+        }
+      });
+    });
+
+  </script>
+</head>
+
+<body>
+  <h1>New Heuristic Random Demo</h1>
+  <div class="topnav">
+    <button id="reset" class="button">Restart</button>
+    <br /> <br />
+    <button id="newHeuristic" class="button">New Heuristic</button>
+    <br /> <br />                
+    <button id="undo" class="button">Undo</button>
+    <button id="redo" class="button">Redo</button>
+
+    <form>
+      <p style="position: relative;">
+        <label for="layout" style="vertical-align:middle;">
+          Rearrange on changes
+        </label>
+        <input type="checkbox" class="input" id="layout" name="layout" style="vertical-align:middle; margin-bottom: 10px;">
+      </p>
+      <p>
+        <label for="siblingWeight">Sibling Weight</label>
+        <input id="siblingWeight" style="width:60px; margin-bottom: 10px!important;" type="number" step="0.25"
+          min=".25" value="0.7">
+      </p>
+      <p>
+        <label for="initialNodeCount">Initial Node Count</label>
+        <input id="initialNodeCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="5"
+          min="5" value="10">
+      </p>
+      <p>
+        <label for="averageDegree">Average Degree</label>
+        <input id="averageDegree" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
+          min="0" max="10" value="2">
+      </p>
+      <p>
+        <label for="compoundNodeRatio">Compound Node Ratio</label>
+        <input id="compoundNodeRatio" style="width:60px; margin-bottom: 10px!important;" type="number" step="0.1"
+          min="0" max="0.5" value="0.1">
+      </p>
+      <p>
+        <label for="averageChildrenCount">Average Children Count</label>
+        <input id="averageChildrenCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
+          min="0" max="10" value="2">
+      </p>
+      <br/>
+      <p>
+        <label for="newNodeCount">New Node Count</label>
+        <input id="newNodeCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
+          min="0" max="10" value="2">
+      </p>
+    </form>
+    <div style="display: flex;">
+      <span style="background-color: #8FE388; width: 16px; height: 16px; margin-right: 10px;"></span>
+      <span>Rank 0</span>
+    </div>
+    <div style="display: flex;">
+      <span style="background-color: #D36135; width: 16px; height: 16px; margin-right: 10px;"></span>
+      <span>Rank 1</span>
+    </div>
+    <div style="display: flex;">
+      <span style="background-color: #279AF1; width: 16px; height: 16px; margin-right: 10px;"></span>
+      <span>Rank 2</span>
+    </div>
+    <div style="display: flex;">
+      <span style="background-color: #89043D; width: 16px; height: 16px; margin-right: 10px;"></span>
+      <span>Rank 3</span>
+    </div>
+    <div style="display: flex;">
+      <span style="background-color: #6E44FF; width: 16px; height: 16px; margin-right: 10px;"></span>
+      <span>Existing Node</span>
+    </div>
+    <br/>
+    <div>
+      Node name convention: <b>{a}{b}-{c}[-{d}]</b>
+      <br/>
+      <b>a:</b> "n" for new nodes, "c" for initial nodes
+      <br/>
+      <b>b:</b> # of iteration where this node is placed
+      <br/>
+      <b>c:</b> # of node in the iteration
+      <br/>
+      <b>d:</b> (Optional) indicates auxiliary node
+    </div>
+  </div>
+  <div id="cy"></div>
+
+</body>
+
+</html>

--- a/newHeuristicDemo.html
+++ b/newHeuristicDemo.html
@@ -22,9 +22,6 @@
     body {
       font-family: helvetica neue, helvetica, liberation sans, arial, sans-serif;
       font-size: 14px;
-    }
-
-    .container {
       display: flex;
     }
 
@@ -70,13 +67,12 @@
     }
 
     #cy {
-      flex: 0.8;
+      flex: 1;
       overflow: hidden;
 
     }
 
     .topnav {
-      flex: 0.2;
       background-color: #e9e9e9;
       /* font-weight: bold;*/
       border-color: black;
@@ -186,14 +182,6 @@
             }
           },
           {
-            selector: 'node:selected',
-            style: {
-              'border-color': 'orange',
-              'border-width': '3px',
-              'background-color': 'lightgrey'
-            }
-          },
-          {
             selector: 'node:parent',
             style: {
               'background-color': 'lightgrey'
@@ -225,6 +213,14 @@
             style: {
               'border-color': '#89043D',
               'border-width': '5px'
+            }
+          },
+          {
+            selector: 'node:selected',
+            style: {
+              'border-color': 'orange',
+              'border-width': '3px',
+              'background-color': 'lightgrey'
             }
           },
         ],
@@ -382,6 +378,18 @@
           }
 
           if (neighborCount) {
+            const addDummyNodes = function(dummyNodeCount, currentNodes) {
+              let nodeToConnect = currentNodes[Math.floor(Math.random() * currentNodes.length)];
+              for (let i = 0; i < dummyNodeCount; i++) {
+                    // Add necessary dummy nodes
+                    const dummyID = `${id}-d${i}`;
+                    const dummyNode = cy.add({ group: 'nodes', data: { id: dummyID, name: dummyID}});
+                    cy.add({ group: 'edges', data: { id: `${dummyID}-e`, source: nodeToConnect.id(), target: dummyID }})
+                    nodeToConnect = dummyNode;
+                    newNodes.merge(dummyNode)
+                    availableNewNodes.merge(dummyNode)
+                  }
+            }
             const forbiddenNodes = cy.collection();
             forbiddenNodes.merge(newNode);
             forbiddenNodes.merge(newNode.ancestors());
@@ -389,17 +397,12 @@
             const availableNewNodes = newNodes.difference(forbiddenNodes)
             const availableCurrentNodes = selectedNodes.length > 0 ? selectedNodes : currentNodes.difference(forbiddenNodes)
             const selectedNeighbors = [];
-            switch (Math.ceil(Math.random() * 3)) {
-              case 1: { // All new neighbors
+            switch (Math.ceil(Math.random() * 5)) {
+              case 1:
+              case 2: { // All new neighbors
                 if (selectedNodes.length === 0) {
                   const dummyNodeCount = neighborCount - availableNewNodes.length;
-                  for (let i = 0; i < dummyNodeCount; i++) {
-                    // Add necessary dummy nodes
-                    const dummyID = `${id}-d${i}`;
-                    const dummyNode = cy.add({ group: 'nodes', data: { id: dummyID, name: dummyID}});
-                    newNodes.merge(dummyNode)
-                    availableNewNodes.merge(dummyNode)
-                  }
+                  addDummyNodes(dummyNodeCount, availableCurrentNodes);
                   for (let i = 0; i < neighborCount; i++) {
                     let randomNeighbor;
                     do {
@@ -411,7 +414,7 @@
                   break;
                 }
               }
-              case 2: { // All existing neighbors
+              case 3: { // All existing neighbors
                 const availableCount = Math.min(neighborCount, availableCurrentNodes.length);
                 for (let i = 0; i < availableCount; i++) {
                   let randomNeighbor;
@@ -423,15 +426,10 @@
                 }
                 break;
               }
-              case 3: { // Both
+              case 4:
+              case 5: { // Both
                 const dummyNodeCount = neighborCount / 2 - availableNewNodes.length;
-                for (let i = 0; i < dummyNodeCount; i++) {
-                  // Add necessary dummy nodes
-                  const dummyID = `${id}-d${i}`;
-                  const dummyNode = cy.add({ group: 'nodes', data: { id: dummyID, name: dummyID}});
-                  newNodes.merge(dummyNode)
-                  availableNewNodes.merge(dummyNode)
-                }
+                addDummyNodes(dummyNodeCount, availableCurrentNodes);
                 for (let i = 0; i < neighborCount; i++) {
                   let randomNeighbor;
                   do {
@@ -517,83 +515,88 @@
 </head>
 
 <body>
-  <h1>New Heuristic Random Demo</h1>
-  <div class='container'>
-    <div class="topnav">
-      <button id="reset" class="button">Restart</button>
-      <br /> <br />
-      <button id="newHeuristic" class="button">New Heuristic</button>
-      <br /> <br />   
-      <button id="rearrange" class="button">Rearrange</button>
-      <br /> <br />              
-      <button id="undo" class="button">Undo</button>
-      <button id="redo" class="button">Redo</button>
-      <br /> <br />
-      <form>
-        <p>
-          <label for="siblingWeight">Sibling Weight</label>
-          <input id="siblingWeight" style="width:60px; margin-bottom: 10px!important;" type="number" step="0.25"
-            min=".25" value="0.7">
-        </p>
-        <p>
-          <label for="initialNodeCount">Initial Node Count</label>
-          <input id="initialNodeCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="5"
-            min="5" value="10">
-        </p>
-        <p>
-          <label for="averageDegree">Average Degree</label>
-          <input id="averageDegree" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
-            min="0" max="10" value="2">
-        </p>
-        <p>
-          <label for="compoundNodeRatio">Compound Node Ratio</label>
-          <input id="compoundNodeRatio" style="width:60px; margin-bottom: 10px!important;" type="number" step="0.1"
-            min="0" max="0.5" value="0.1">
-        </p>
-        <p>
-          <label for="averageChildrenCount">Average Children Count</label>
-          <input id="averageChildrenCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
-            min="0" max="10" value="2">
-        </p>
+    <div>
+      <h1>New Heuristic Random Demo</h1>
+      <div class="topnav">   
+        <button id="reset" class="button">Restart</button>
+        <br /> <br />
+        <button id="newHeuristic" class="button">New Heuristic</button>
+        <br /> <br />   
+        <button id="rearrange" class="button">Rearrange</button>
+        <br /> <br />              
+        <button id="undo" class="button">Undo</button>
+        <button id="redo" class="button">Redo</button>
+        <br /> <br />
+        <form>
+          <p style="position: relative;">
+            <label for="layout" style="vertical-align:middle;">
+              Rearrange on changes
+            </label>
+            <input type="checkbox" class="input" id="layout" name="layout" style="vertical-align:middle; margin-bottom: 10px;">
+          </p>
+          <p>
+            <label for="siblingWeight">Sibling Weight</label>
+            <input id="siblingWeight" style="width:60px; margin-bottom: 10px!important;" type="number" step="0.25"
+              min=".25" value="0.7">
+          </p>
+          <p>
+            <label for="initialNodeCount">Initial Node Count</label>
+            <input id="initialNodeCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="5"
+              min="5" value="10">
+          </p>
+          <p>
+            <label for="averageDegree">Average Degree</label>
+            <input id="averageDegree" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
+              min="0" max="10" value="2">
+          </p>
+          <p>
+            <label for="compoundNodeRatio">Compound Node Ratio</label>
+            <input id="compoundNodeRatio" style="width:60px; margin-bottom: 10px!important;" type="number" step="0.1"
+              min="0" max="0.5" value="0.1">
+          </p>
+          <p>
+            <label for="averageChildrenCount">Average Children Count</label>
+            <input id="averageChildrenCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
+              min="0" max="10" value="2">
+          </p>
+          <br/>
+          <p>
+            <label for="newNodeCount">New Node Count</label>
+            <input id="newNodeCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
+              min="0" max="10" value="2">
+          </p>
+        </form>
+        <div style="display: flex;">
+          <span style="background-color: #8FE388; width: 16px; height: 16px; margin-right: 10px;"></span>
+          <span>Rank 0</span>
+        </div>
+        <div style="display: flex;">
+          <span style="background-color: #D36135; width: 16px; height: 16px; margin-right: 10px;"></span>
+          <span>Rank 1</span>
+        </div>
+        <div style="display: flex;">
+          <span style="background-color: #279AF1; width: 16px; height: 16px; margin-right: 10px;"></span>
+          <span>Rank 2</span>
+        </div>
+        <div style="display: flex;">
+          <span style="background-color: #89043D; width: 16px; height: 16px; margin-right: 10px;"></span>
+          <span>Rank 3</span>
+        </div>
         <br/>
-        <p>
-          <label for="newNodeCount">New Node Count</label>
-          <input id="newNodeCount" style="width:60px; margin-bottom: 10px!important;" type="number" step="1"
-            min="0" max="10" value="2">
-        </p>
-      </form>
-      <div style="display: flex;">
-        <span style="background-color: #8FE388; width: 16px; height: 16px; margin-right: 10px;"></span>
-        <span>Rank 0</span>
-      </div>
-      <div style="display: flex;">
-        <span style="background-color: #D36135; width: 16px; height: 16px; margin-right: 10px;"></span>
-        <span>Rank 1</span>
-      </div>
-      <div style="display: flex;">
-        <span style="background-color: #279AF1; width: 16px; height: 16px; margin-right: 10px;"></span>
-        <span>Rank 2</span>
-      </div>
-      <div style="display: flex;">
-        <span style="background-color: #89043D; width: 16px; height: 16px; margin-right: 10px;"></span>
-        <span>Rank 3</span>
-      </div>
-      <br/>
-      <div>
-        Node name convention: <b>{a}{b}-{c}[-{d}]</b>
-        <br/>
-        <b>a:</b> "n" for new nodes, "c" for initial nodes
-        <br/>
-        <b>b:</b> # of iteration where this node is placed
-        <br/>
-        <b>c:</b> # of node in the iteration
-        <br/>
-        <b>d:</b> (Optional) indicates auxiliary node
+        <div>
+          Node name convention: <b>{a}{b}-{c}[-{d}]</b>
+          <br/>
+          <b>a:</b> "n" for new nodes, "c" for initial nodes
+          <br/>
+          <b>b:</b> # of iteration where this node is placed
+          <br/>
+          <b>c:</b> # of node in the iteration
+          <br/>
+          <b>d:</b> (Optional) indicates auxiliary node
+        </div>
       </div>
     </div>
     <div id="cy"></div>
-  </div>
-
 </body>
 
 </html>

--- a/src/core/layout-utilities.js
+++ b/src/core/layout-utilities.js
@@ -46,56 +46,6 @@ var layoutUtilities = function (cy, options) {
     return this.filterByScratchProp({nodes: node.siblings(), prop: 'calculated', value: true });
   };
 
-  instance.placeNewNodesNewHeuristic = function (newNodes) {
-    // Remove temporary extension data remained from prior operations
-    cy.nodes().forEach(node => node.removeScratch(extensionName));
-    
-    const currentNodes = cy.nodes(':visible').difference(newNodes);
-    currentNodes.forEach(node => this.setScratchProp({node, prop: 'calculated', value: true}));
-    const maxRank = this.rankNodes(newNodes, currentNodes);
-    const postponedNodes = [];
-    for (let i = 0; i <= maxRank; i++) {
-      let compounds = [];
-      for (const node of this.filterByScratchProp({nodes: newNodes, prop: 'rank', value: i})) {
-        if (node.isParent()) {
-          compounds.push(node);
-        } else if (node.isChild() && newNodes.contains(node.parent())) {
-          // If it is inside a new node, escalate its neighbors to parent
-          const escalatedNeighbors = this.getScratchProp({node: node.parent(), prop: 'escalatedNeighbors', defaultValue: [] });
-          this.setScratchProp({node: node.parent(), prop: 'escalatedNeighbors', value: [...escalatedNeighbors, ...this.getCalculatedNeighbors(node)]})
-        } else if (i === 0 && node.neighborhood().nodes().length !== 0 && node.isOrphan()) {
-          // Postpone this type of nodes since their neighbors will be placed after
-          postponedNodes.push(node);
-        } else {
-          this.setOptimumPosition(node);
-        }
-      }
-      compounds = this.sortByHierarchy(compounds);
-      for (const node of compounds) {
-        const escalatedNeighbors = this.getScratchProp({node, prop: 'escalatedNeighbors', defaultValue: [] });
-        if (node.isChild() && newNodes.contains(node.parent())) {
-          // If this compound node is inside another new node, escalete the neighbors to parent
-          const parentNeighbors = this.getScratchProp({node: node.parent(), prop: 'escalatedNeighbors', defaultValue: [] });
-          this.setScratchProp({node: node.parent(), prop: 'escalatedNeighbors', value: [...parentNeighbors, ...this.getCalculatedNeighbors(node), ...escalatedNeighbors]})
-        } else {
-          // Calculate optimum position of the compound node with respect to siblings and neighbors
-          const siblings = this.getCalculatedSiblings(node)
-          const siblingPositions = siblings.map(e => e.position());
-          const siblingAvg = this.getAvgPos(siblingPositions);
-
-          const uniqueNeighbors = [...new Set([...escalatedNeighbors, ...this.getCalculatedNeighbors(node)])];
-          const neighborsAvg = this.getAvgPos(uniqueNeighbors.map(e => e.position()));
-          
-          const calculatedAvgPos = this.getSiblingNeighborAverage(siblingAvg, neighborsAvg);
-          this.placeCompoundNode(node, calculatedAvgPos, options.idealEdgeLength);
-        }
-      }
-    }
-    for (const node of postponedNodes) {
-      this.setOptimumPosition(node);
-    }
-  };
-
   /** Get an average point between siblings average and neighbors average, with respect to siblingWeight */
   instance.getSiblingNeighborAverage = function (siblingAvg, neighborsAvg) {
     switch (true) {
@@ -266,211 +216,61 @@ var layoutUtilities = function (cy, options) {
     }
     return maxRank;
   };
-  
+
   instance.placeHiddenNodes = function (mainEles) {
     mainEles.forEach(function (mainEle) {
       var hiddenEles = mainEle.neighborhood().nodes(":hidden");
-      hiddenEles.forEach(function (hiddenEle) {
-        var neighbors = hiddenEle.neighborhood().nodes(":visible");
-        if (neighbors.length > 1) {
-          instance.nodeWithMultipleNeighbors(hiddenEle);
-        } else instance.nodeWithOneNeighbor(mainEle, hiddenEle);
-      });
+      instance.placeNewNodes(hiddenEles);
     });
   };
 
-  instance.placeNewNodes = function (eles) {
-    var components = this.findComponents(eles);
-    var disconnectedComp = [];
-    for (var i = 0; i < components.length; i++) {
-      var oneNeig = false;
-      var multNeig = false;
-      var mainEle;
-      var multneighbors = [];
-      var positioned = [];
-      var x = 0;
-      var y = 0;
-      var isPositioned = false;
-      for (var j = 0; j < components[i].length; j++) {
-        var neighbors = components[i][j].neighborhood().nodes().difference(eles);
-        positioned.push(false);
-        if (neighbors.length > 1 && !isPositioned) {
-          multNeig = true;
-          positioned[j] = true;
-          multneighbors = neighbors;
-          instance.nodeWithMultipleNeighbors(components[i][j], multneighbors);
-          x = components[i][j].position("x");
-          y = components[i][j].position("y");
-          isPositioned = true;
-        }
-        else if (neighbors.length == 1 && !isPositioned) {
-          oneNeig = true;
-          mainEle = neighbors[0];
-          positioned[j] = true;
-          instance.nodeWithOneNeighbor(mainEle, components[i][j], eles);
-          x = components[i][j].position("x");
-          y = components[i][j].position("y");
-          isPositioned = true;
+  instance.placeNewNodes = function (newNodes) {
+    // Remove temporary extension data remained from prior operations
+    cy.nodes().forEach(node => node.removeScratch(extensionName));
+    
+    const currentNodes = cy.nodes(':visible').difference(newNodes);
+    currentNodes.forEach(node => this.setScratchProp({node, prop: 'calculated', value: true}));
+    const maxRank = this.rankNodes(newNodes, currentNodes);
+    const postponedNodes = [];
+    for (let i = 0; i <= maxRank; i++) {
+      let compounds = [];
+      for (const node of this.filterByScratchProp({nodes: newNodes, prop: 'rank', value: i})) {
+        if (node.isParent()) {
+          compounds.push(node);
+        } else if (node.isChild() && newNodes.contains(node.parent())) {
+          // If it is inside a new node, escalate its neighbors to parent
+          const escalatedNeighbors = this.getScratchProp({node: node.parent(), prop: 'escalatedNeighbors', defaultValue: [] });
+          this.setScratchProp({node: node.parent(), prop: 'escalatedNeighbors', value: [...escalatedNeighbors, ...this.getCalculatedNeighbors(node)]})
+        } else if (i === 0 && node.neighborhood().nodes().length !== 0 && node.isOrphan()) {
+          // Postpone this type of nodes since their neighbors will be placed after
+          postponedNodes.push(node);
+        } else {
+          this.setOptimumPosition(node);
         }
       }
+      compounds = this.sortByHierarchy(compounds);
+      for (const node of compounds) {
+        const escalatedNeighbors = this.getScratchProp({node, prop: 'escalatedNeighbors', defaultValue: [] });
+        if (node.isChild() && newNodes.contains(node.parent())) {
+          // If this compound node is inside another new node, escalete the neighbors to parent
+          const parentNeighbors = this.getScratchProp({node: node.parent(), prop: 'escalatedNeighbors', defaultValue: [] });
+          this.setScratchProp({node: node.parent(), prop: 'escalatedNeighbors', value: [...parentNeighbors, ...this.getCalculatedNeighbors(node), ...escalatedNeighbors]})
+        } else {
+          // Calculate optimum position of the compound node with respect to siblings and neighbors
+          const siblings = this.getCalculatedSiblings(node)
+          const siblingPositions = siblings.map(e => e.position());
+          const siblingAvg = this.getAvgPos(siblingPositions);
 
-      if (oneNeig || multNeig) {
-        for (var j = 0; j < components[i].length; j++) {
-          if (positioned[j] == false) {
-            var neighbors = components[i][j].neighborhood().nodes();
-            var positionedNeigbors = [];
-            var curr = components[i][j].neighborhood().nodes().difference(eles);
-            curr.forEach(function (ele) {
-              positionedNeigbors.push(ele);
-            })
-
-            for (var k = 0; k < neighbors.length; k++) {
-              if (positioned[components[i].indexOf(neighbors[k])]) {
-                positionedNeigbors.push(neighbors[k]);
-              }
-            }
-            if (positionedNeigbors.length > 1) {
-              instance.nodeWithMultipleNeighbors(components[i][j], positionedNeigbors);
-            } else if (positionedNeigbors.length == 1) instance.nodeWithOneNeighbor(positionedNeigbors[0], components[i][j]);
-            else {
-              var horizontalP = instance.generateRandom(options.offset, options.offset * 2, 0);
-              var verticalP = instance.generateRandom(options.offset, options.offset * 2, 0);
-              components[i][j].position("x", x + horizontalP);
-              components[i][j].position("y", y + verticalP);
-            }
-            positioned[j] = true;
-          }
+          const uniqueNeighbors = [...new Set([...escalatedNeighbors, ...this.getCalculatedNeighbors(node)])];
+          const neighborsAvg = this.getAvgPos(uniqueNeighbors.map(e => e.position()));
+          
+          const calculatedAvgPos = this.getSiblingNeighborAverage(siblingAvg, neighborsAvg);
+          this.placeCompoundNode(node, calculatedAvgPos, options.idealEdgeLength);
         }
-      }
-      else {
-        disconnectedComp.push(components[i]);
       }
     }
-
-    if (disconnectedComp.length >= 1) {
-      instance.disconnectedNodes(disconnectedComp);
-    }
-  };
-
-  instance.disconnectedNodes = function (components) {
-    var leftX = Number.MAX_VALUE;
-    var rightX = -Number.MAX_VALUE;
-    var topY = Number.MAX_VALUE;
-    var bottomY = -Number.MAX_VALUE;
-    // Check the x and y limits of all hidden elements and store them in the variables above
-    cy.nodes(':visible').forEach(function (node) {
-      var halfWidth = node.outerWidth() / 2;
-      var halfHeight = node.outerHeight() / 2;
-      if (node.position("x") - halfWidth < leftX)
-        leftX = node.position("x") - halfWidth;
-      if (node.position("x") + halfWidth > rightX)
-        rightX = node.position("x") + halfWidth;
-      if (node.position("y") - halfHeight < topY)
-        topY = node.position("y") - halfHeight;
-      if (node.position("y") + halfHeight > bottomY)
-        bottomY = node.position("y") + halfHeight;
-    });
-
-    var radiusy = topY - bottomY;
-    var radiusx = rightX - leftX;
-    var innerRadius = (Math.sqrt(radiusx * radiusx + radiusy * radiusy)) / 2;
-    var centerX = (leftX + rightX) / 2;
-    var centerY = (topY + bottomY) / 2;
-    //var components = this.findComponents(newEles);
-    var numOfComponents = components.length;
-    var angle = 360 / numOfComponents;
-    var count = 1;
-
-    components.forEach(function (component) {
-
-      var distFromCenter = instance.generateRandom(innerRadius + options.offset * 6, innerRadius + options.offset * 8, 1);
-      var curAngle = angle * count;
-      var angleInRadians = curAngle * Math.PI / 180;
-      var x = centerX + distFromCenter * Math.cos(angleInRadians);
-      var y = centerY + distFromCenter * Math.sin(angleInRadians);
-
-      if (component.length == 1) {
-        component[0].position("x", x);
-        component[0].position("y", y);
-      }
-      else {
-        var positioned = [];
-        for (var i = 0; i < component.length; i++) {
-          positioned.push(false);
-        }
-
-        positioned[0] = true;
-        component[0].position("x", x);
-        component[0].position("y", y);
-
-        for (var i = 1; i < component.length; i++) {
-          var neighbors = component[i].neighborhood().nodes();
-          var positionedNeigbors = [];
-          for (var j = 0; j < neighbors.length; j++) {
-            if (positioned[component.indexOf(neighbors[j])]) {
-              positionedNeigbors.push(neighbors[j]);
-            }
-          }
-          if (positionedNeigbors.length > 1) {
-            instance.nodeWithMultipleNeighbors(component[i], positionedNeigbors);
-          } else if (positionedNeigbors.length == 1) instance.nodeWithOneNeighbor(positionedNeigbors[0], component[i]);
-          else {
-            var horizontalP = instance.generateRandom(options.offset, options.offset * 2, 0);
-            var verticalP = instance.generateRandom(options.offset, options.offset * 2, 0);
-            component[i].position("x", x + horizontalP);
-            component[i].position("y", y + verticalP);
-          }
-          positioned[i] = true;
-        }
-      }
-      count++;
-    });
-  };
-
-  instance.findComponents = function (newEles) {
-
-    var adjListArray = [];
-    var current = cy.nodes().difference(newEles);
-    newEles.forEach(function (ele) {
-      var neighbors = ele.neighborhood().nodes().difference(current);
-      var listOfIndexes = [];
-      neighbors.forEach(function (neigbor) {
-        var index = newEles.indexOf(neigbor);
-        listOfIndexes.push(index);
-      });
-      adjListArray.push(listOfIndexes);
-    });
-
-    // Mark all the vertices as not visited 
-    var visited = [];
-    for (var v = 0; v < newEles.length; v++) {
-      visited.push(false);
-    }
-
-    var listOfComponents = [];
-
-
-    for (var v = 0; v < newEles.length; v++) {
-      var elesOfComponent = [];
-      if (visited[v] == false) {
-        // print all reachable vertices 
-        // from v 
-        this.DFSUtil(v, visited, adjListArray, newEles, elesOfComponent);
-        listOfComponents.push(elesOfComponent);
-      }
-    }
-
-    return listOfComponents;
-  };
-
-  instance.DFSUtil = function (v, visited, adjListArray, newEles, elesOfComponent) {
-    // Mark the current node as visited and print it 
-    visited[v] = true;
-    elesOfComponent.push(newEles[v]);
-    // Recur for all the vertices 
-    // adjacent to this vertex 
-    for (var i = 0; i < adjListArray[v].length; i++) {
-      if (!visited[adjListArray[v][i]]) this.DFSUtil(adjListArray[v][i], visited, adjListArray, newEles, elesOfComponent);
+    for (const node of postponedNodes) {
+      this.setOptimumPosition(node);
     }
   };
 
@@ -537,26 +337,6 @@ var layoutUtilities = function (cy, options) {
     var newCenterY = mainEle.position("y") + verticalParam;
     unplacedEle.position("x", newCenterX);
     unplacedEle.position("y", newCenterY);
-  };
-
-  instance.nodeWithMultipleNeighbors = function (ele, neighbors) {
-    if (neighbors == null) {
-      var neighbors = ele.neighborhood().nodes(":visible");
-    }
-    var x = 0;
-    var y = 0;
-    var count = 0;
-    neighbors.forEach(function (ele1) {
-      x += ele1.position("x");
-      y += ele1.position("y");
-      count++;
-    });
-    x = x / count;
-    y = y / count;
-    var diffx = instance.generateRandom(0, options.offset / 2, 0);
-    var diffy = instance.generateRandom(0, options.offset / 2, 0);
-    ele.position("x", x + diffx);
-    ele.position("y", y + diffy);
   };
 
   instance.generateRandom = function (min, max, mult) {

--- a/src/core/layout-utilities.js
+++ b/src/core/layout-utilities.js
@@ -130,6 +130,7 @@ var layoutUtilities = function (cy, options) {
     for (const node of postponedCompounds) {
       this.placeCompoundNode(node, getOptimumPos(node, coordinate, offset), offset / 2);
     }
+    placedNode.data('calculated', true);
   };
 
   /** Sort given nodes so that most inner compound will come first in the sorted list */

--- a/src/core/layout-utilities.js
+++ b/src/core/layout-utilities.js
@@ -4,6 +4,7 @@ var polyominoPacking = require('./polyomino-packing');
 const { Point, Polyomino } = require('./polyomino-packing');
 const { getCenter } = require('./general-utils.js');
 const pose = require('../pose/pose.js');
+const extensionName = 'layout_utilities';
 
 var layoutUtilities = function (cy, options) {
   
@@ -15,21 +16,53 @@ var layoutUtilities = function (cy, options) {
     options[name] = val;
   };
 
+  instance.setScratchProp = function ({node, scratchName = extensionName, prop, value}) {
+    const scratch = node.scratch(scratchName);
+    if (scratch) {
+      scratch[prop] = value;
+      node.scratch(scratchName, scratch);
+    } else {
+      node.scratch(scratchName, { [prop]: value} );
+    }
+  };
+
+  instance.getScratchProp = function ({node, scratchName = extensionName, prop, defaultValue}) {
+    const { [prop]: result = defaultValue } = node.scratch(scratchName) || {};
+    return result;
+  };
+
+  instance.filterByScratchProp = function ({nodes, scratchName = extensionName, prop, value}) {
+    return nodes.filter(node => {
+      const { [prop]: propValue } = node.scratch(scratchName) || {};
+      return propValue === value;
+    })
+  };
+
+  instance.getCalculatedNeighbors = function (node) {
+    return this.filterByScratchProp({nodes: node.neighborhood().nodes(), prop: 'calculated', value: true });
+  };
+
+  instance.getCalculatedSiblings = function (node) {
+    return this.filterByScratchProp({nodes: node.siblings(), prop: 'calculated', value: true });
+  };
+
   instance.placeNewNodesNewHeuristic = function (newNodes) {
+    // Remove temporary extension data remained from prior operations
+    cy.nodes().forEach(node => node.removeScratch(extensionName));
+    
     const currentNodes = cy.nodes(':visible').difference(newNodes);
-    currentNodes.forEach(node => node.data('calculated', true));
+    currentNodes.forEach(node => this.setScratchProp({node, prop: 'calculated', value: true}));
     const maxRank = this.rankNodes(newNodes, currentNodes);
     const postponedNodes = [];
     for (let i = 0; i <= maxRank; i++) {
       let compounds = [];
-      for (const node of newNodes.filter(`node[rank=${i}]`)) {
+      for (const node of this.filterByScratchProp({nodes: newNodes, prop: 'rank', value: i})) {
         if (node.isParent()) {
           compounds.push(node);
         } else if (node.isChild() && newNodes.contains(node.parent())) {
           // If it is inside a new node, escalate its neighbors to parent
-          const neighbors = node.neighborhood().nodes().filter('node[calculated]');
-          const escalatedNeighbors = node.parent().data('escalatedNeighbors');
-          node.parent().data('escalatedNeighbors', [...(escalatedNeighbors || []), ...neighbors]);
+          const escalatedNeighbors = this.getScratchProp({node: node.parent(), prop: 'escalatedNeighbors', defaultValue: [] });
+          this.setScratchProp({node: node.parent(), prop: 'escalatedNeighbors', value: [...escalatedNeighbors, ...this.getCalculatedNeighbors(node)]})
         } else if (i === 0 && node.neighborhood().nodes().length !== 0 && node.isOrphan()) {
           // Postpone this type of nodes since their neighbors will be placed after
           postponedNodes.push(node);
@@ -39,20 +72,18 @@ var layoutUtilities = function (cy, options) {
       }
       compounds = this.sortByHierarchy(compounds);
       for (const node of compounds) {
+        const escalatedNeighbors = this.getScratchProp({node, prop: 'escalatedNeighbors', defaultValue: [] });
         if (node.isChild() && newNodes.contains(node.parent())) {
           // If this compound node is inside another new node, escalete the neighbors to parent
-          const escalatedNeighbors = node.parent().data('escalatedNeighbors');
-          const nodesNeighbors = node.neighborhood().filter('node[calculated]');
-          node.parent().data('escalatedNeighbors', [...(escalatedNeighbors || []), 
-                                                    ...nodesNeighbors,
-                                                    ...(node.data('escalatedNeighbors') || [])]);
+          const parentNeighbors = this.getScratchProp({node: node.parent(), prop: 'escalatedNeighbors', defaultValue: [] });
+          this.setScratchProp({node: node.parent(), prop: 'escalatedNeighbors', value: [...parentNeighbors, ...this.getCalculatedNeighbors(node), ...escalatedNeighbors]})
         } else {
           // Calculate optimum position of the compound node with respect to siblings and neighbors
-          const siblingPositions = node.siblings().filter('node[calculated]').map(e => e.position());
+          const siblings = this.getCalculatedSiblings(node)
+          const siblingPositions = siblings.map(e => e.position());
           const siblingAvg = this.getAvgPos(siblingPositions);
 
-          const neighbors = [...node.data('escalatedNeighbors'), ...node.neighborhood().filter('node[calculated]')];
-          const uniqueNeighbors = [...new Set(neighbors)];
+          const uniqueNeighbors = [...new Set([...escalatedNeighbors, ...this.getCalculatedNeighbors(node)])];
           const neighborsAvg = this.getAvgPos(uniqueNeighbors.map(e => e.position()));
           
           const calculatedAvgPos = this.getSiblingNeighborAverage(siblingAvg, neighborsAvg);
@@ -112,7 +143,8 @@ var layoutUtilities = function (cy, options) {
   instance.placeCompoundNode = function (placedNode, coordinate, offset) {
     const getOptimumPos = function (node, coordinate, offset) {
       // Calculate the optimum position according to the average point of the neighbors and suggested coordinate
-      const allNeighbors = [...node.neighborhood().filter('node[calculated]'), ...(node.data('escalatedNeighbors') || [])];
+      const escalatedNeighbors = this.getScratchProp({node, prop: 'escalatedNeighbors', defaultValue: [] });
+      const allNeighbors = [...this.getCalculatedNeighbors(node), ...escalatedNeighbors];
       const neighborsAvg = this.getAvgPos(allNeighbors.map(e => e.position()));
       const weightedMiddlePoint = this.getWeightedMiddlePoint(coordinate, neighborsAvg, offset);
       return this.getPositionWithOffset(weightedMiddlePoint, offset);
@@ -124,13 +156,13 @@ var layoutUtilities = function (cy, options) {
         postponedCompounds.push(node);
       } else {
         node.position(getOptimumPos(node, coordinate, offset));
-        node.data('calculated', true);
+        this.setScratchProp({node, prop: 'calculated', value: true});
       }
     }
     for (const node of postponedCompounds) {
       this.placeCompoundNode(node, getOptimumPos(node, coordinate, offset), offset / 2);
     }
-    placedNode.data('calculated', true);
+    this.setScratchProp({node: placedNode, prop: 'calculated', value: true});
   };
 
   /** Sort given nodes so that most inner compound will come first in the sorted list */
@@ -175,9 +207,9 @@ var layoutUtilities = function (cy, options) {
   };
 
   instance.setOptimumPosition = function (node) {
-    const siblings = node.siblings().filter('node[calculated]');
-    const neighbors = node.neighborhood().filter('node[calculated]');
-
+    const neighbors = this.getCalculatedNeighbors(node);
+    const siblings = this.getCalculatedSiblings(node);
+  
     const siblingAvg = this.getAvgPos(siblings.map(e => e.position()));
     const neighborsAvg = this.getAvgPos(neighbors.map(e => e.position()));
 
@@ -189,7 +221,7 @@ var layoutUtilities = function (cy, options) {
       const newPosition = this.getSiblingNeighborAverage(siblingAvg, neighborsAvg);
       node.position(this.getPositionWithOffset(newPosition));
     }
-    node.data('calculated', true);
+    this.setScratchProp({node, prop: 'calculated', value: true});
   };
 
   instance.rankNodes = function (newNodes, currentNodes) {
@@ -203,7 +235,7 @@ var layoutUtilities = function (cy, options) {
         let calculatedRank = -1;
 
         const neighborNodes = node.neighborhood().nodes();
-        const ranksOfNeighbors = neighborNodes.filter('node[rank]').map(e => e.data('rank'));
+        const ranksOfNeighbors = neighborNodes.map(node => this.getScratchProp({node, prop: 'rank'})).filter(e => e);
         if (neighborNodes.intersection(currentNodes).length > 0) {
           calculatedRank = 1;
         } else if (ranksOfNeighbors.length > 0) {
@@ -211,10 +243,11 @@ var layoutUtilities = function (cy, options) {
         }
 
         if (calculatedRank !== -1) {
-          node.data("rank", calculatedRank);
+          this.setScratchProp({node, prop: 'rank', value: calculatedRank});
           maxRank = Math.max(maxRank, calculatedRank);
           for (const anc of node.ancestors()) {
-            anc.data("rank", Math.max(anc.data("rank") || 0, calculatedRank));
+            const ancRank = this.getScratchProp({node: anc, prop: 'rank', defaultValue: 0 });
+            this.setScratchProp({node: anc, prop: 'rank', value: Math.max(ancRank, calculatedRank)});
           }
           unrankedNodes.splice(j, 1);
         }
@@ -224,10 +257,10 @@ var layoutUtilities = function (cy, options) {
     // If all n iterations are done and there are still unrankedNodes, it means that
     // they should be rank 0
     for (const node of unrankedNodes) {
-      node.data("rank", 0);
+      this.setScratchProp({node, prop: 'rank', value: 0});
       for (const anc of node.ancestors()) {
         if (!anc.data("rank")) {
-          anc.data("rank", 0);
+          this.setScratchProp({node: anc, prop: 'rank', value: 0});
         }
       }
     }


### PR DESCRIPTION
Implementing a new algorithm for determining the initial positions of newly added nodes. 
It uses a new heuristic, which takes nodes whose neighbors are also new and compound nodes into account.

There is also a new demo file for testing purposes of the new heuristic.

## Purposes of the Buttons
- **Restart:** Removes all the existing nodes in the current graph and generate random initial nodes from scratch
- **New Heuristic:** Adds new nodes to the graph with random scenarios.
- **Undo:** Reverts the last node addition
- **Redo:** Reapplies the reverted addition

## Settings
- **Sibling Weight**: How close should the new node be to the average point of siblings. (Other point is neighbor average)
- **Initial Node Count**: How many nodes will be initialized on Restart
- **Average Degree:** Average neighbor count of the nodes
- **Compound Node Ratio:** Among all initial nodes, how many of them should be compound node (Compound / All ratio)
- **Average Children Count:** Average children count of the initial compound nodes
- **New Node Count:** How many nodes should be added in each "New Heuristic" click

